### PR TITLE
Establish Phase 11 content direction and tracking

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -80,8 +80,10 @@ asset scripts outside the phase that authorizes them.
 - Validate content at build time and keep stable IDs for claims, evidence,
   projects, metrics, and tracker items.
 - Preserve existing article source during content-pipeline migrations.
-- Do not introduce WebGL, React Three Fiber, or a heavy animation runtime for
-  decorative effect.
+- Phase 11 may use a focused, progressively loaded WebGL/React Three Fiber
+  client island only when it communicates the approved system flow. It must
+  not block content, replace semantic controls, or run for purely decorative
+  effect.
 - Never expose environment secrets, private URLs, or confidential Velsa
   implementation details.
 
@@ -112,7 +114,9 @@ asset scripts outside the phase that authorizes them.
 
 ## Content and route rules
 
-- The primary position is "Senior frontend-leaning full-stack engineer".
+- Use "Senior full-stack engineer" for H1s, metadata, structured data, and
+  prominent labels. Use "Frontend-leaning full-stack engineer" only in
+  summaries and descriptive positioning.
 - The main CV CTA downloads the ATS PDF; the visual CV is secondary.
 - System-design notes belong under `/writing` until a separate route is
   explicitly approved.

--- a/docs/content-inventory.md
+++ b/docs/content-inventory.md
@@ -19,7 +19,11 @@ These facts may enter the Phase 1 claim registry as `approved`.
 ### Profile
 
 - Saqib Sohail; Berlin, Germany.
-- Senior frontend-leaning full-stack engineer with 8+ years of experience.
+- Prominent title: Senior full-stack engineer.
+- Descriptive positioning: Frontend-leaning full-stack engineer.
+- 8+ years of software-engineering experience.
+- 7+ products and platforms across verified professional and public-project
+  work. This is a user-approved Phase 11 claim.
 - Frontend: React, Next.js, TypeScript, JavaScript, Vue.js, Nuxt.js, HTML, CSS.
 - Backend: Python, Django, FastAPI, Node.js, Ruby on Rails, REST APIs.
 - Data/applied AI: PostgreSQL, MySQL, vector databases, RAG, LLM integration.

--- a/docs/decisions-and-risks.md
+++ b/docs/decisions-and-risks.md
@@ -1,6 +1,6 @@
 # Decisions and Risks
 
-**Last updated:** 2026-07-24
+**Last updated:** 2026-07-25
 
 **Decision authority:** Approved rebuild plan and Phase 0 repository audit
 
@@ -32,6 +32,9 @@
 | D-021 | Make selected web fonts optional and keep mobile H1s on a stable local serif fallback | Preload fonts with `swap`; remove the serif identity | Prevents late font application from becoming the mobile LCP while preserving the CV-inspired pairing when the fonts are available | Accepted |
 | D-022 | Accept a bounded 161 kB shared-runtime JavaScript exception for this release | Rework the approved Next App Router architecture; block release indefinitely | The user approved the 31 kB difference after local measurements confirmed all user-facing LCP, accessibility, SEO, and CLS targets pass | Accepted 2026-07-25; re-measure after material framework or client-island changes |
 | D-023 | Permit controlled production verification through PR #11 before protected-preview manual testing | Wait for a Vercel bypass; directly push to `master` | Vercel SSO prevents external preview verification and the user approved production validation; the PR must have passing checks and any rollback must be a revert commit | Accepted 2026-07-25; production verification remains required before release completion |
+| D-024 | Use “Senior full-stack engineer” as the prominent title and “Frontend-leaning full-stack engineer” as descriptive positioning | Repeat the longer positioning in every title surface | Removes duplicated hero language while retaining the approved frontend emphasis in summaries | Accepted 2026-07-25 |
+| D-025 | Use `8+ years` and `7+ products & platforms` as homepage proof | Keep Tactical Tech’s 30% and 50% outcomes in the global proof strip | Keeps role-specific outcomes in their evidence context and uses the user-approved cross-portfolio count on the homepage | Accepted 2026-07-25 |
+| D-026 | Add progressive focused graphics for Phase 11 | Keep the Phase 5 SVG-only flow; make WebGL a blocking page dependency | The user approved richer animation; server-rendered content, semantic controls, fallbacks, and performance gates remain mandatory | Accepted 2026-07-25 |
 
 ## Risk register
 
@@ -55,6 +58,8 @@
 | R-016 | CV files drift from website facts | Medium / Medium | Stable downloads and shared release checklist comparing dates/title/languages | Phases 1/10 | Every CV replacement | Open |
 | R-017 | Source Sans/Serif loading harms LCP or privacy | Low / Medium | Use local `next/font` assets, optional non-preloaded loading, stable mobile H1 fallback, and repeatable Lighthouse evidence | Phases 4/10 | Any typography or font-weight change | Mitigated |
 | R-018 | Locked Next 16.2.11 carries nested high advisories | High / High | Stable `postcss`/`sharp` overrides resolve the nested paths; re-run production audit before merge | Phase 3 | Any Next or override update | Mitigated |
+| R-019 | Phase 11 animation increases first-load cost, motion burden, or input latency | Medium / High | Defer animation islands, pause them off-screen, lower mobile DPR, respect reduced motion/save-data, and measure core/deferred chunks separately | Phase 11 | Homepage preview and every animation dependency change | Open |
+| R-020 | Interactive architecture diagrams hide information from keyboard or assistive-technology users | Medium / High | Keep DOM controls and complete ordered-text equivalents; test keyboard, touch, no-JS, and reduced-motion states | Phase 11 | Case-study preview | Open |
 
 ## Deferred decisions with defaults
 

--- a/docs/implementation-status.md
+++ b/docs/implementation-status.md
@@ -1,12 +1,12 @@
 # Implementation Status
 
-**Current phase:** Phase 10 — SEO, performance, documentation, and release
+**Current phase:** Phase 11 — Visual systems and case-study redesign
 
-**Current branch:** `phase-10-production-evidence` (final evidence PR)
+**Current branch:** `agent/phase-11-content-foundation`
 
 **Last updated:** 2026-07-25
 
-**Overall state:** DONE; deployed production verification and the user-confirmed manual accessibility review are complete
+**Overall state:** IN PROGRESS; factual content direction and tracking are being established before visual work
 
 ## Status rules
 
@@ -38,6 +38,7 @@ whose status changes.
 | 8. Writing experience/review | DONE | Phases 2, 4 | Separate PR |
 | 9. Accessibility security gate | DONE (promotion DEFERRED) | Phase 3; external evidence | Separate PR |
 | 10. SEO/performance/docs/release | DONE | Phases 5–9 dispositions | PRs #11–#13; production verification and manual review complete |
+| 11. Visual systems/case-study redesign | IN PROGRESS | Phase 10 production baseline | Four reviewable PRs; visual work requires screenshot approval |
 
 ## Phase 0 — Audit, governance, and tracking
 
@@ -169,6 +170,22 @@ whose status changes.
 | P10.05 | Capture three-run median Lighthouse results | DONE | Local production build | Phase 10 report; twelve local and twelve live-production Lighthouse 12.8.2 JSON reports under `/tmp` | Re-measure after material framework, global client-island, or delivery changes |
 | P10.06 | Pass performance and accessibility release budgets | DONE | P10.05 | Three-run local medians meet LCP (1.71–1.83 s), accessibility/SEO (100), and CLS (0); user approved the documented 161 kB shared-runtime exception on 2026-07-25 | Re-measure and revisit the exception if framework, global client islands, or first-load script composition changes materially |
 | P10.07 | Verify redirects, downloads, CI, manual checklist, and preview | DONE | P10.01–P10.06 | Production checks pass after repair PR #12: routes/details/downloads, redirects, metadata, screenshots, theme, keyboard skip focus, touch flow, no-JS content, and four three-run Lighthouse medians; user confirmed the remaining manual review on 2026-07-25 | Re-run the release checklist after material route, interaction, accessibility, framework, or delivery changes |
+
+## Phase 11 — Visual systems and case-study redesign
+
+| ID | Deliverable / acceptance criterion | Status | Dependency | Evidence | Next action / revisit |
+| --- | --- | --- | --- | --- | --- |
+| P11.01 | Split prominent title from descriptive positioning across content, metadata, structured data, and experience | DONE | Phase 10 baseline | `src/content/portfolio.ts`, root metadata/JSON-LD, OG image, experience H1, unit tests | Keep title usage covered during homepage redesign |
+| P11.02 | Register the user-approved `7+ products & platforms` proof and homepage proof selection | DONE | P11.01 | Claim registry, metric model, content inventory, unit tests | Render only the two approved proof cards in the homepage PR |
+| P11.03 | Remove stale/incomplete public copy without strengthening claims | IN PROGRESS | P11.01–P11.02 | Content scan and browser tests planned | Complete with homepage and dossier copy changes |
+| P11.04 | Build the progressive homepage hero signal and Systems Lab with semantic fallbacks | NOT STARTED | P11.01–P11.03 | Pending | Start after content-foundation PR |
+| P11.05 | Redesign homepage proof, selected work, capabilities, writing, and contact composition | NOT STARTED | P11.04 | Pending | Implement with homepage systems PR |
+| P11.06 | Add validated architecture nodes/edges, structured outcomes, and optional dossier sections | NOT STARTED | P11.03 | Pending | Start in case-study data commit |
+| P11.07 | Apply the engineering-dossier template to every published case study | NOT STARTED | P11.06 | Pending | Begin with Jobs Tracker Bot |
+| P11.08 | Add accessible deferred architecture maps and text equivalents | NOT STARTED | P11.06–P11.07 | Pending | Test keyboard, touch, no-JS, and fit-to-view |
+| P11.09 | Capture and review light/dark desktop/mobile visuals including 200% zoom | NOT STARTED | P11.04–P11.08 | Pending | User approval required before visual merge |
+| P11.10 | Pass clean install, lint, typecheck, unit, browser, axe, build, audit, and Lighthouse gates | NOT STARTED | P11.04–P11.09 | Pending | Measure core and deferred chunks separately |
+| P11.11 | Add Phase 11 completion report and release through reviewed PRs | NOT STARTED | P11.01–P11.10 | Pending | Do not merge visual work before screenshot review |
 
 ## Blockers
 

--- a/src/app/experience/page.tsx
+++ b/src/app/experience/page.tsx
@@ -19,7 +19,7 @@ export default function ExperiencePage() {
   return <article className="experience-page">
     <header className="experience-hero">
       <p className="eyebrow">Experience</p>
-      <h1>{profile.positioning}</h1>
+      <h1>{profile.title}</h1>
       <p>{profile.summary}</p>
       <p className="experience-location">{profile.location}</p>
       <div className="homepage-actions">

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -26,7 +26,7 @@ const siteUrl = 'https://ssohail.com';
 
 export const metadata: Metadata = {
   title: {
-    default: `${profile.name} — ${profile.positioning}`,
+    default: `${profile.name} — ${profile.title}`,
     template: `%s | ${profile.name}`,
   },
   description: profile.proposition,
@@ -54,7 +54,7 @@ export const metadata: Metadata = {
     canonical: '/',
   },
   openGraph: {
-    title: `${profile.name} — ${profile.positioning}`,
+    title: `${profile.name} — ${profile.title}`,
     description: profile.proposition,
     url: siteUrl,
     siteName: `${profile.name} Portfolio`,
@@ -63,7 +63,7 @@ export const metadata: Metadata = {
   },
   twitter: {
     card: 'summary',
-    title: `${profile.name} — ${profile.positioning}`,
+    title: `${profile.name} — ${profile.title}`,
     description: profile.proposition,
   },
   robots: {
@@ -109,7 +109,7 @@ export default function RootLayout({
           <JsonLd data={[
             {
               '@context': 'https://schema.org', '@type': 'Person', name: profile.name, url: siteUrl,
-              jobTitle: profile.positioning, email: profile.email, address: { '@type': 'PostalAddress', addressLocality: 'Berlin', addressCountry: 'DE' },
+              jobTitle: profile.title, email: profile.email, address: { '@type': 'PostalAddress', addressLocality: 'Berlin', addressCountry: 'DE' },
               sameAs: [profile.githubUrl, profile.linkedinUrl],
             },
             { '@context': 'https://schema.org', '@type': 'WebSite', name: `${profile.name} Portfolio`, url: siteUrl, inLanguage: 'en' },

--- a/src/app/opengraph-image.tsx
+++ b/src/app/opengraph-image.tsx
@@ -1,6 +1,6 @@
 import { ImageResponse } from 'next/og';
 
-export const alt = 'Saqib Sohail — Senior frontend-leaning full-stack engineer';
+export const alt = 'Saqib Sohail — Senior full-stack engineer';
 export const size = { width: 1200, height: 630 };
 export const contentType = 'image/png';
 
@@ -9,7 +9,7 @@ export default function OpenGraphImage() {
     <div style={{ height: '100%', width: '100%', display: 'flex', flexDirection: 'column', justifyContent: 'space-between', padding: '72px', background: '#081014', color: '#f3f7f8' }}>
       <div style={{ display: 'flex', color: '#46bdd0', fontSize: 28, letterSpacing: 5, textTransform: 'uppercase' }}>Saqib Sohail</div>
       <div style={{ display: 'flex', flexDirection: 'column', gap: 24 }}>
-        <div style={{ display: 'flex', maxWidth: 930, fontSize: 76, fontWeight: 700, lineHeight: 1.02, letterSpacing: -4 }}>Senior frontend-leaning full-stack engineer</div>
+        <div style={{ display: 'flex', maxWidth: 930, fontSize: 76, fontWeight: 700, lineHeight: 1.02, letterSpacing: -4 }}>Senior full-stack engineer</div>
         <div style={{ display: 'flex', maxWidth: 880, color: '#bed0d5', fontSize: 32, lineHeight: 1.35 }}>Accessible product systems across React interfaces, Python services, and applied AI.</div>
       </div>
       <div style={{ display: 'flex', color: '#bed0d5', fontSize: 24 }}>ssohail.com · Berlin, Germany</div>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -12,8 +12,8 @@ export default function HomePage() {
   return (
     <div className="homepage">
       <section className="homepage-hero" aria-labelledby="homepage-title">
-        <p className="eyebrow">Berlin, Germany · {profile.positioning}</p>
-        <h1 id="homepage-title">{profile.headline}</h1>
+        <p className="eyebrow">{profile.location}</p>
+        <h1 id="homepage-title">{profile.title}</h1>
         <p className="homepage-proposition">{profile.proposition}</p>
         <div className="homepage-actions">
           <a className="button button-primary" href={profile.downloads.ats}>Download ATS CV</a>

--- a/src/content/portfolio.ts
+++ b/src/content/portfolio.ts
@@ -80,6 +80,12 @@ const evidence: EvidenceRef[] = [
     description: 'Profile, positioning, skills, education, and language facts.',
   },
   {
+    id: 'approved-products-platforms',
+    status: 'approved',
+    source: 'User-approved Phase 11 portfolio brief',
+    description: 'Seven or more products and platforms across verified professional and public-project work.',
+  },
+  {
     id: 'approved-velsa',
     status: 'approved',
     source: 'Approved portfolio brief',
@@ -127,6 +133,13 @@ const metrics: Metric[] = [
     label: 'years in software engineering',
     context: 'Senior frontend-leaning full-stack engineering experience.',
     evidenceIds: ['approved-profile'],
+  },
+  {
+    id: 'products-platforms',
+    value: '7+',
+    label: 'products & platforms',
+    context: 'Verified professional and public-project work.',
+    evidenceIds: ['approved-products-platforms'],
   },
   {
     id: 'tactical-platforms',
@@ -385,9 +398,9 @@ export const portfolioContent = {
   profile: {
     name: 'Saqib Sohail',
     location: 'Berlin, Germany',
-    positioning: 'Senior frontend-leaning full-stack engineer',
-    headline: 'Senior frontend-leaning full-stack engineer',
-    proposition: 'I design and build accessible product systems across React interfaces, Python services and applied AI.',
+    title: 'Senior full-stack engineer',
+    positioning: 'Frontend-leaning full-stack engineer',
+    proposition: 'Frontend-leaning engineer building accessible product interfaces, dependable service boundaries, and applied-AI workflows.',
     summary: 'Eight years of experience turning complex workflows into maintainable web products—from frontend architecture and legacy modernisation to API integration and AI-assisted features.',
     email: 'saqib@ssohail.com',
     website: 'https://ssohail.com',
@@ -403,6 +416,7 @@ export const portfolioContent = {
       visual: '/downloads/saqib-sohail-cv-visual.pdf',
     },
   },
+  homepageMetricIds: ['experience-years', 'products-platforms'],
   evidence,
   metrics,
   roles,
@@ -467,6 +481,7 @@ export function validatePortfolioContent(content: PortfolioContent = portfolioCo
 
   const evidenceById = new Map(content.evidence.map((item) => [item.id, item]));
   const evidenceIds = new Set(evidenceById.keys());
+  const metricsById = new Map(content.metrics.map((item) => [item.id, item]));
   const roleIds = new Set(content.roles.map((item) => item.id));
   const projectSlugs = new Set(content.projects.map((item) => item.slug));
 
@@ -528,6 +543,12 @@ export function validatePortfolioContent(content: PortfolioContent = portfolioCo
     assert(item.categories.length > 0, `writing "${item.id}" has no categories`);
   }
 
+  assert(content.profile.title === 'Senior full-stack engineer', 'profile title must use the approved prominent title');
+  assert(content.profile.positioning === 'Frontend-leaning full-stack engineer', 'profile positioning must use the approved descriptive wording');
+  for (const metricId of content.homepageMetricIds) {
+    assert(metricsById.has(metricId), `homepage metric "${metricId}" does not exist`);
+  }
+  assert(new Set(content.homepageMetricIds).size === content.homepageMetricIds.length, 'homepage metrics contain a duplicate');
   assert(content.profile.downloads.ats.startsWith('/downloads/'), 'ATS download path is invalid');
   assert(content.profile.downloads.visual.startsWith('/downloads/'), 'visual download path is invalid');
 }

--- a/tests/e2e/experience.spec.ts
+++ b/tests/e2e/experience.spec.ts
@@ -7,7 +7,7 @@ test('legacy CV redirects permanently to experience', async ({ page, request }) 
 
   await page.goto('/cv');
   await expect(page).toHaveURL(/\/experience$/);
-  await expect(page.getByRole('heading', { level: 1 })).toContainText('Senior frontend-leaning full-stack engineer');
+  await expect(page.getByRole('heading', { level: 1 })).toHaveText('Senior full-stack engineer');
 });
 
 test('experience exposes both CV downloads', async ({ page, request }, testInfo) => {

--- a/tests/e2e/no-javascript.spec.ts
+++ b/tests/e2e/no-javascript.spec.ts
@@ -5,7 +5,7 @@ test('primary content remains understandable without JavaScript', async ({ brows
   const page = await context.newPage();
 
   await page.goto('/');
-  await expect(page.getByRole('heading', { level: 1 })).toContainText('Senior frontend-leaning full-stack engineer');
+  await expect(page.getByRole('heading', { level: 1 })).toHaveText('Senior full-stack engineer');
   await expect(page.getByText('Product problem → Interface → API → Service → Data/AI → Production')).toBeVisible();
 
   await page.goto('/writing/web-accessibility-2025');

--- a/tests/portfolio-content.test.ts
+++ b/tests/portfolio-content.test.ts
@@ -4,6 +4,32 @@ import { portfolioContent } from '@/content/portfolio';
 import { caseStudies, caseStudySectionKeys, validateCaseStudies } from '@/content/caseStudies';
 
 describe('portfolio content', () => {
+  it('keeps the prominent title distinct from descriptive positioning', () => {
+    expect(portfolioContent.profile.title).toBe('Senior full-stack engineer');
+    expect(portfolioContent.profile.positioning).toBe('Frontend-leaning full-stack engineer');
+    expect(portfolioContent.profile.title).not.toBe(portfolioContent.profile.positioning);
+  });
+
+  it('publishes only the approved homepage proof metrics', () => {
+    const homepageMetrics = portfolioContent.homepageMetricIds.map((id) =>
+      portfolioContent.metrics.find((metric) => metric.id === id),
+    );
+
+    expect(homepageMetrics).toEqual([
+      expect.objectContaining({
+        id: 'experience-years',
+        value: '8+',
+        evidenceIds: ['approved-profile'],
+      }),
+      expect.objectContaining({
+        id: 'products-platforms',
+        value: '7+',
+        evidenceIds: ['approved-products-platforms'],
+      }),
+    ]);
+    expect(homepageMetrics.every(Boolean)).toBe(true);
+  });
+
   it('contains unique project and writing slugs', () => {
     const projectSlugs = portfolioContent.projects.map(({ slug }) => slug);
     const writingSlugs = portfolioContent.writing.map(({ slug }) => slug);


### PR DESCRIPTION
## What changed

- split the prominent `Senior full-stack engineer` title from descriptive frontend-leaning positioning
- update metadata, Open Graph, JSON-LD, experience, and homepage title surfaces
- register the user-approved `7+ products & platforms` claim and homepage proof selection
- add Phase 11 decisions, risks, tracker IDs, and repository guidance
- update unit and browser assertions for the new title contract

## Why

The existing hero repeated the same long positioning twice and the homepage proof strip removed role-specific outcomes from their proper evidence context. This establishes the factual and tracking foundation before the visual redesign.

## Validation

- `npm run lint`
- `npm run typecheck`
- `npm run test` (19 passed)
- `npm run test:e2e` (29 passed)
- `npm run build`

The visual redesign is intentionally not included in this foundation PR.
