### PR TITLE
Redesign case studies as engineering dossiers

### DIFF
--- a/docs/implementation-status.md
+++ b/docs/implementation-status.md
@@ -2,7 +2,7 @@
 
 **Current phase:** Phase 11 — Visual systems and case-study redesign
 
-**Current branch:** `agent/phase-11-homepage` (stacked on content foundation PR #14)
+**Current branch:** `agent/phase-11-case-studies` (stacked on homepage PR #15)
 
 **Last updated:** 2026-07-25
 
@@ -177,12 +177,12 @@ whose status changes.
 | --- | --- | --- | --- | --- | --- |
 | P11.01 | Split prominent title from descriptive positioning across content, metadata, structured data, and experience | DONE | Phase 10 baseline | `src/content/portfolio.ts`, root metadata/JSON-LD, OG image, experience H1, unit tests | Keep title usage covered during homepage redesign |
 | P11.02 | Register the user-approved `7+ products & platforms` proof and homepage proof selection | DONE | P11.01 | Claim registry, metric model, content inventory, unit tests | Render only the two approved proof cards in the homepage PR |
-| P11.03 | Remove stale/incomplete public copy without strengthening claims | IN PROGRESS | P11.01–P11.02 | Content scan and browser tests planned | Complete with homepage and dossier copy changes |
+| P11.03 | Remove stale/incomplete public copy without strengthening claims | DONE | P11.01–P11.02 | Homepage/dossier source scan, case-study validator, and browser assertions reject the targeted incomplete-work wording | Keep the validator current if new case-study fields are added |
 | P11.04 | Build the progressive homepage hero signal and Systems Lab with semantic fallbacks | DONE | P11.01–P11.03 | `HeroSignalCanvas`, `SystemsLab`, deferred R3F topology, GSAP stage sync, keyboard/touch/reduced-motion/save-data/no-JS browser tests | Re-measure animation chunks and LCP in the final QA PR |
 | P11.05 | Redesign homepage proof, selected work, capabilities, writing, and contact composition | DONE | P11.04 | Server homepage composition; inspected light desktop and mobile captures; 32 browser tests and 7 two-theme axe routes pass | Re-capture from the final stacked preview for user approval |
-| P11.06 | Add validated architecture nodes/edges, structured outcomes, and optional dossier sections | NOT STARTED | P11.03 | Pending | Start in case-study data commit |
-| P11.07 | Apply the engineering-dossier template to every published case study | NOT STARTED | P11.06 | Pending | Begin with Jobs Tracker Bot |
-| P11.08 | Add accessible deferred architecture maps and text equivalents | NOT STARTED | P11.06–P11.07 | Pending | Test keyboard, touch, no-JS, and fit-to-view |
+| P11.06 | Add validated architecture nodes/edges, structured outcomes, and optional dossier sections | DONE | P11.03 | Typed `CaseStudyOutcome`, `ArchitectureNode`, and `ArchitectureEdge`; required-section and dangling-edge tests; unsupported sections absent | Revalidate when case-study content changes |
+| P11.07 | Apply the engineering-dossier template to every published case study | DONE | P11.06 | Shared full-width hero/outcomes, responsive TOC, grouped chapters, decision cards, private evidence boundary, and inspected Jobs/private captures | Re-capture light/dark desktop/mobile from final preview |
+| P11.08 | Add accessible deferred architecture maps and text equivalents | DONE | P11.06–P11.07 | Deferred React Flow map, keyboard node selection, fit controls, ordered text equivalent, no-JS coverage, and 10 two-theme axe routes passing | Verify touch/zoom and final preview interaction |
 | P11.09 | Capture and review light/dark desktop/mobile visuals including 200% zoom | NOT STARTED | P11.04–P11.08 | Pending | User approval required before visual merge |
 | P11.10 | Pass clean install, lint, typecheck, unit, browser, axe, build, audit, and Lighthouse gates | NOT STARTED | P11.04–P11.09 | Pending | Measure core and deferred chunks separately |
 | P11.11 | Add Phase 11 completion report and release through reviewed PRs | NOT STARTED | P11.01–P11.10 | Pending | Do not merge visual work before screenshot review |

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@google/generative-ai": "^0.24.1",
         "@react-three/fiber": "^9.6.1",
+        "@xyflow/react": "^12.11.2",
         "framer-motion": "^12.42.2",
         "gray-matter": "^4.0.3",
         "gsap": "^3.15.0",
@@ -2539,6 +2540,55 @@
         "assertion-error": "^2.0.1"
       }
     },
+    "node_modules/@types/d3-color": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-3.1.3.tgz",
+      "integrity": "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-drag": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/@types/d3-drag/-/d3-drag-3.0.7.tgz",
+      "integrity": "sha512-HE3jVKlzU9AaMazNufooRJ5ZpWmLIoc90A37WU2JMmeq28w1FQqCZswHZ3xR+SuxYftzHq6WU6KJHvqxKzTxxQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-selection": "*"
+      }
+    },
+    "node_modules/@types/d3-interpolate": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-3.0.4.tgz",
+      "integrity": "sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-color": "*"
+      }
+    },
+    "node_modules/@types/d3-selection": {
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/@types/d3-selection/-/d3-selection-3.0.11.tgz",
+      "integrity": "sha512-bhAXu23DJWsrI45xafYpkQ4NtcKMwWnAC/vKrd2l+nxMFuvOT3XMYTIj2opv8vq8AO5Yh7Qac/nSeP/3zjTK0w==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-transition": {
+      "version": "3.0.9",
+      "resolved": "https://registry.npmjs.org/@types/d3-transition/-/d3-transition-3.0.9.tgz",
+      "integrity": "sha512-uZS5shfxzO3rGlu0cC3bjmMFKsXv+SmZZcgp0KD22ts4uGXp5EVYGzu/0YdwZeKmddhcAccYtREJKkPfXkZuCg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-selection": "*"
+      }
+    },
+    "node_modules/@types/d3-zoom": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/@types/d3-zoom/-/d3-zoom-3.0.8.tgz",
+      "integrity": "sha512-iqMC4/YlFCSlO8+2Ii1GGGliCAY4XdeG748w5vQUbevlbDu0zSjH/+jojorQVBK/se0j6DUFNPBGSqD3YWYnDw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-interpolate": "*",
+        "@types/d3-selection": "*"
+      }
+    },
     "node_modules/@types/debug": {
       "version": "4.1.12",
       "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.12.tgz",
@@ -2615,7 +2665,7 @@
       "version": "19.2.3",
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.3.tgz",
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "peer": true,
       "peerDependencies": {
@@ -3455,6 +3505,76 @@
       "dev": true,
       "license": "BSD-3-Clause"
     },
+    "node_modules/@xyflow/react": {
+      "version": "12.11.2",
+      "resolved": "https://registry.npmjs.org/@xyflow/react/-/react-12.11.2.tgz",
+      "integrity": "sha512-eLAlDWJfWnQEhJwGMjlWdAXO9eYllKpliUmPQlAmOLxz6mExXuzMVDUKLMquixgkrtmMFFtug3jGKmYYld12cA==",
+      "license": "MIT",
+      "dependencies": {
+        "@xyflow/system": "0.0.79",
+        "classcat": "^5.0.3",
+        "zustand": "^4.4.0"
+      },
+      "peerDependencies": {
+        "@types/react": ">=17",
+        "@types/react-dom": ">=17",
+        "react": ">=17",
+        "react-dom": ">=17"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@xyflow/react/node_modules/zustand": {
+      "version": "4.5.7",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-4.5.7.tgz",
+      "integrity": "sha512-CHOUy7mu3lbD6o6LJLfllpjkzhHXSBlX8B9+qPddUsIfeF5S/UZ5q0kmCsnRqT1UHFQZchNFDDzMbQsuesHWlw==",
+      "license": "MIT",
+      "dependencies": {
+        "use-sync-external-store": "^1.2.2"
+      },
+      "engines": {
+        "node": ">=12.7.0"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.8",
+        "immer": ">=9.0.6",
+        "react": ">=16.8"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "immer": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@xyflow/system": {
+      "version": "0.0.79",
+      "resolved": "https://registry.npmjs.org/@xyflow/system/-/system-0.0.79.tgz",
+      "integrity": "sha512-czLyOh91NF0hIzbNzwi8I6GlqG23BHh2435OddfI6uiaLH3xdrdygO93gqgH1Bv9mhy8XPFQJOBn1FTq4LvEWA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-drag": "^3.0.7",
+        "@types/d3-interpolate": "^3.0.4",
+        "@types/d3-selection": "^3.0.10",
+        "@types/d3-transition": "^3.0.8",
+        "@types/d3-zoom": "^3.0.8",
+        "d3-drag": "^3.0.0",
+        "d3-interpolate": "^3.0.1",
+        "d3-selection": "^3.0.0",
+        "d3-zoom": "^3.0.0"
+      }
+    },
     "node_modules/acorn": {
       "version": "8.17.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.17.0.tgz",
@@ -4083,6 +4203,12 @@
         "node": ">=18"
       }
     },
+    "node_modules/classcat": {
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/classcat/-/classcat-5.0.5.tgz",
+      "integrity": "sha512-JhZUT7JFcQy/EzW605k/ktHtncoo9vnyW/2GspNYwFlN1C/WmjuV/xtS04e9SOkL2sTdw0VAZ2UGCcQ9lR6p6w==",
+      "license": "MIT"
+    },
     "node_modules/client-only": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/client-only/-/client-only-0.0.1.tgz",
@@ -4213,6 +4339,112 @@
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
       "license": "MIT"
+    },
+    "node_modules/d3-color": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
+      "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-dispatch": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-dispatch/-/d3-dispatch-3.0.1.tgz",
+      "integrity": "sha512-rzUyPU/S7rwUflMyLc1ETDeBj0NRuHKKAcvukozwhshr6g6c5d8zh4c2gQjY2bZ0dXeGLWc1PF174P2tVvKhfg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-drag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-drag/-/d3-drag-3.0.0.tgz",
+      "integrity": "sha512-pWbUJLdETVA8lQNJecMxoXfH6x+mO2UQo8rSmZ+QqxcbyA3hfeprFgIT//HW2nlHChWeIIMwS2Fq+gEARkhTkg==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-selection": "3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-ease": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
+      "integrity": "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-interpolate": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
+      "integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-selection": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
+      "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
+      "license": "ISC",
+      "peer": true,
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-timer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz",
+      "integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-transition": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-transition/-/d3-transition-3.0.1.tgz",
+      "integrity": "sha512-ApKvfjsSR6tg06xrL434C0WydLr7JewBB3V+/39RMHsaXTOG0zmt/OAXeng5M5LBm0ojmxJrpomQVZ1aPvBL4w==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3",
+        "d3-dispatch": "1 - 3",
+        "d3-ease": "1 - 3",
+        "d3-interpolate": "1 - 3",
+        "d3-timer": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "peerDependencies": {
+        "d3-selection": "2 - 3"
+      }
+    },
+    "node_modules/d3-zoom": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-zoom/-/d3-zoom-3.0.0.tgz",
+      "integrity": "sha512-b8AmV3kfQaqWAuacbPuNbL6vahnOJflOhexLzMMNLga62+/nh0JzvJ0aO/5a5MVgUFGS7Hu1P9P03o3fJkDCyw==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-drag": "2 - 3",
+        "d3-interpolate": "1 - 3",
+        "d3-selection": "2 - 3",
+        "d3-transition": "2 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/damerau-levenshtein": {
       "version": "1.0.8",

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
   "dependencies": {
     "@google/generative-ai": "^0.24.1",
     "@react-three/fiber": "^9.6.1",
+    "@xyflow/react": "^12.11.2",
     "framer-motion": "^12.42.2",
     "gray-matter": "^4.0.3",
     "gsap": "^3.15.0",

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -512,33 +512,130 @@ a { color: inherit; }
   .systems-lab-details .eyebrow { margin-bottom: 0.75rem; }
 }
 
-.work-page, .case-study { width: min(100% - 2rem, 72rem); margin: 0 auto; padding: clamp(4rem, 8vw, 7rem) 0; }
-.work-hero, .case-study > header { max-width: 52rem; margin-bottom: 3rem; }
-.work-hero h1, .case-study h1 { margin: 0; font-size: clamp(2.7rem, 6vw, 5rem); line-height: 1; letter-spacing: -0.04em; }
-.work-hero > p:last-child, .case-study > header > p:last-child { color: var(--text-muted); font-size: 1.15rem; line-height: 1.6; }
-.work-grid { display: grid; grid-template-columns: repeat(2, 1fr); gap: 1rem; }
-.work-card { padding: 1.7rem; border: 1px solid var(--border); border-radius: 0.7rem; background: var(--surface); }
-.work-card h2 { margin: 0; font-size: 1.7rem; }
-.work-card > p:not(.project-card-label) { color: var(--text-muted); line-height: 1.55; }
-.work-card ul { display: flex; flex-wrap: wrap; gap: .4rem; padding: 0; list-style: none; }
-.work-card li { border-radius: 999px; background: var(--surface-muted); padding: .25rem .55rem; color: var(--text-muted); font-size: .8rem; }
-.work-card a { color: var(--accent-strong); font-weight: 750; }
-.case-study > nav { margin-bottom: 2rem; color: var(--text-muted); font-size: .9rem; }
-.case-study-facts { display: grid; grid-template-columns: repeat(2, 1fr); margin: 0 0 3rem; border-block: 1px solid var(--border); }
-.case-study-facts div { padding: 1.25rem 0; }
-.case-study-facts dt { color: var(--text-muted); font-size: .78rem; font-weight: 750; letter-spacing: .1em; text-transform: uppercase; }
-.case-study-facts dd { margin: .45rem 0 0; font-weight: 650; }
-.architecture-flow { margin: 0 0 4rem; padding: 1.5rem; border: 1px solid var(--border); border-radius: .7rem; background: var(--surface-muted); }
-.architecture-flow figcaption { margin-bottom: 1rem; font-weight: 750; }
-.architecture-flow ol { display: grid; grid-template-columns: repeat(6, 1fr); gap: .55rem; padding: 0; counter-reset: flow; list-style: none; }
-.architecture-flow li { min-height: 5.5rem; padding: .8rem; border: 1px solid var(--border); border-radius: .45rem; background: var(--surface); font-size: .85rem; font-weight: 650; }
-.case-study-body { display: grid; grid-template-columns: minmax(0, 1fr) minmax(0, 2fr); column-gap: 3rem; }
-.case-study-body section { grid-column: 2; padding: 1.5rem 0; border-top: 1px solid var(--border); }
-.case-study-body h2, .case-study-outcomes h2 { margin: 0 0 .65rem; font-size: 1.65rem; }
-.case-study-body p { margin: 0; color: var(--text-muted); font-size: 1.05rem; line-height: 1.7; }
-.case-study-outcomes { margin-top: 3rem; padding: 2rem; border-radius: .7rem; background: var(--surface-muted); }
-@media (max-width: 800px) { .architecture-flow ol { grid-template-columns: repeat(2, 1fr); } .case-study-body { display: block; } }
-@media (max-width: 600px) { .work-page, .case-study { width: min(100% - 1.25rem, 72rem); } .work-grid, .case-study-facts { grid-template-columns: 1fr; } }
+.work-page { width: min(100% - 2rem, 78rem); margin: 0 auto; padding: clamp(4rem, 8vw, 7rem) 0; }
+.work-hero { max-width: 56rem; margin-bottom: clamp(3rem, 7vw, 6rem); }
+.work-hero h1 { margin: 0; font-size: clamp(3rem, 7vw, 6.3rem); line-height: .92; letter-spacing: -.055em; }
+.work-hero > p:last-child { max-width: 46rem; color: var(--text-muted); font-size: 1.15rem; line-height: 1.6; }
+.work-grid { border-top: 1px solid var(--border); }
+.work-card { display: grid; grid-template-columns: minmax(15rem, .75fr) minmax(0, 1.25fr); column-gap: clamp(2rem, 7vw, 7rem); padding: clamp(2rem, 5vw, 4rem) 0; border-bottom: 1px solid var(--border); }
+.work-card .project-card-label, .work-card h2 { grid-column: 1; }
+.work-card h2 { margin: 0; font-size: clamp(1.8rem, 3.3vw, 3rem); line-height: 1; letter-spacing: -.04em; }
+.work-card > p:not(.project-card-label), .work-card ul, .work-card a { grid-column: 2; }
+.work-card > p:not(.project-card-label) { grid-row: 1 / span 2; margin-top: 0; color: var(--text-muted); font-size: 1.06rem; line-height: 1.65; }
+.work-card ul { display: flex; flex-wrap: wrap; align-self: end; gap: .45rem; padding: 0; margin: 2rem 0 1rem; list-style: none; }
+.work-card li { color: var(--text-muted); font-size: .8rem; }
+.work-card li:not(:last-child)::after { padding-left: .45rem; color: var(--accent); content: ' /'; }
+.work-card a { color: var(--accent-strong); font-weight: 750; text-underline-offset: .25em; }
+
+.dossier { padding: clamp(2.5rem, 5vw, 4.5rem) 0 clamp(5rem, 10vw, 9rem); }
+.dossier-breadcrumb, .dossier-hero, .dossier-layout { width: min(100% - 2rem, 78rem); margin-inline: auto; }
+.dossier-breadcrumb { margin-bottom: clamp(3rem, 7vw, 6rem); color: var(--text-muted); font-size: .86rem; }
+.dossier-breadcrumb a { color: var(--accent-strong); text-decoration: underline; text-underline-offset: .2em; }
+.dossier-hero { display: grid; grid-template-columns: repeat(12, minmax(0, 1fr)); gap: clamp(2rem, 5vw, 5rem); padding-bottom: clamp(4rem, 8vw, 7rem); }
+.dossier-hero-copy { grid-column: 1 / span 8; }
+.dossier-hero h1 { max-width: 12ch; margin: 0; font-size: clamp(3.3rem, 7.3vw, 6.7rem); line-height: .9; letter-spacing: -.06em; text-wrap: balance; }
+.dossier-hero-copy > p:not(.eyebrow) { max-width: 48rem; margin: 1.8rem 0; color: var(--text-muted); font-size: clamp(1.1rem, 2vw, 1.4rem); line-height: 1.55; }
+.dossier-evidence-link { display: inline-flex; gap: .4rem; color: var(--accent-strong); font-weight: 750; text-underline-offset: .3em; }
+.dossier-facts { grid-column: 10 / -1; align-self: end; margin: 0; border-top: 1px solid var(--border); }
+.dossier-facts div { padding: 1rem 0; border-bottom: 1px solid var(--border); }
+.dossier-facts dt { color: var(--accent-strong); font-size: .68rem; font-weight: 750; letter-spacing: .11em; text-transform: uppercase; }
+.dossier-facts dd { margin: .35rem 0 0; color: var(--text-muted); font-size: .9rem; line-height: 1.5; }
+.dossier-outcomes { grid-column: 1 / -1; display: grid; grid-template-columns: repeat(auto-fit, minmax(14rem, 1fr)); margin-top: clamp(2rem, 4vw, 4rem); border-block: 1px solid var(--border); }
+.dossier-outcomes article { min-height: 13rem; padding: 1.5rem clamp(1rem, 3vw, 2.5rem); border-right: 1px solid var(--border); background: linear-gradient(145deg, color-mix(in srgb, var(--accent) 8%, transparent), transparent 68%); }
+.dossier-outcomes article:last-child { border-right: 0; }
+.dossier-outcomes strong { display: block; max-width: 18ch; font-family: var(--font-source-serif), Georgia, serif; font-size: clamp(2rem, 4.4vw, 4.2rem); font-weight: 520; letter-spacing: -.045em; line-height: .95; }
+.dossier-outcomes h2 { margin: 1.5rem 0 .35rem; font-family: var(--font-source-sans), Arial, sans-serif; font-size: 1rem; }
+.dossier-outcomes p { max-width: 28rem; margin: 0; color: var(--text-muted); font-size: .9rem; line-height: 1.5; }
+.evidence-boundary { grid-column: 1 / -1; display: grid; grid-template-columns: 8rem 1fr; gap: 1rem; margin-top: -2rem; padding: 1.25rem 0; border-bottom: 1px solid var(--border); }
+.evidence-boundary > span { color: var(--accent-strong); font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace; font-size: .7rem; letter-spacing: .1em; }
+.evidence-boundary p { max-width: 60rem; margin: 0; color: var(--text-muted); }
+
+.dossier-layout { display: grid; grid-template-columns: minmax(12rem, 16rem) minmax(0, 1fr); gap: clamp(3rem, 8vw, 8rem); align-items: start; }
+.dossier-toc { position: sticky; top: 6.5rem; padding-top: 1rem; border-top: 1px solid var(--border); }
+.dossier-toc > p { margin: 0 0 1rem; color: var(--text-muted); font-size: .72rem; font-weight: 750; letter-spacing: .1em; text-transform: uppercase; }
+.dossier-toc ol { padding: 0; margin: 0; list-style: none; }
+.dossier-toc li + li { margin-top: .85rem; }
+.dossier-toc a { display: grid; grid-template-columns: 2rem 1fr; color: var(--text-muted); font-size: .83rem; line-height: 1.35; text-decoration: none; }
+.dossier-toc a:hover { color: var(--accent-strong); }
+.dossier-toc a span { color: var(--accent-strong); font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace; font-size: .65rem; }
+.dossier-content { min-width: 0; }
+.dossier-chapter { padding: clamp(3.5rem, 7vw, 6.5rem) 0; border-top: 1px solid var(--border); scroll-margin-top: 7rem; }
+.dossier-chapter > header { display: grid; grid-template-columns: 3rem 1fr; align-items: start; margin-bottom: clamp(2rem, 5vw, 4rem); }
+.dossier-chapter > header > span { padding-top: .5rem; color: var(--accent-strong); font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace; font-size: .72rem; }
+.dossier-chapter > header h2 { max-width: 15ch; margin: 0; font-size: clamp(2.2rem, 4.6vw, 4.2rem); line-height: .98; letter-spacing: -.045em; }
+.dossier-narrative { max-width: 72ch; margin-left: 3rem; }
+.dossier-narrative > div + div { margin-top: 2.5rem; }
+.dossier-narrative h3 { margin: 0 0 .65rem; color: var(--accent-strong); font-family: var(--font-source-sans), Arial, sans-serif; font-size: .76rem; letter-spacing: .1em; text-transform: uppercase; }
+.dossier-narrative p { margin: 0; color: var(--text-muted); font-size: 1.08rem; line-height: 1.72; text-wrap: pretty; }
+.dossier-narrative--context { display: grid; max-width: none; grid-template-columns: repeat(3, 1fr); gap: 1.5rem; margin-left: 0; }
+.dossier-narrative--context > div + div { margin-top: 0; }
+.dossier-narrative--context > div { padding-top: 1rem; border-top: 1px solid var(--border); }
+.dossier-narrative--decisions { display: grid; max-width: none; grid-template-columns: repeat(auto-fit, minmax(14rem, 1fr)); gap: 1rem; margin-left: 0; }
+.dossier-narrative--decisions > div, .dossier-narrative--outcome > div { padding: 1.5rem; background: var(--surface-muted); }
+.dossier-narrative--decisions > div + div, .dossier-narrative--outcome > div + div { margin-top: 0; }
+.dossier-narrative--outcome { display: grid; max-width: none; grid-template-columns: repeat(2, 1fr); gap: 1rem; margin-left: 0; }
+
+.dossier-architecture { margin: clamp(3rem, 6vw, 5rem) 0 0; }
+.dossier-architecture > figcaption { margin-bottom: 1rem; color: var(--text-muted); font-size: .75rem; font-weight: 750; letter-spacing: .1em; text-transform: uppercase; }
+.architecture-map { overflow: hidden; border: 1px solid var(--border); background: var(--surface); }
+.architecture-map-placeholder, .architecture-flow-canvas { height: clamp(25rem, 52vw, 38rem); }
+.architecture-map-placeholder { position: relative; display: flex; align-items: center; justify-content: space-around; padding: 3rem; background-image: linear-gradient(color-mix(in srgb, var(--border) 45%, transparent) 1px, transparent 1px), linear-gradient(90deg, color-mix(in srgb, var(--border) 45%, transparent) 1px, transparent 1px); background-size: 2.75rem 2.75rem; }
+.architecture-map-placeholder::before { position: absolute; right: 8%; left: 8%; height: 1px; background: var(--accent); content: ''; }
+.architecture-map-placeholder span { position: relative; z-index: 1; width: .8rem; height: .8rem; border: 2px solid var(--accent); border-radius: 50%; background: var(--surface); }
+.architecture-flow-canvas { color: var(--text); }
+.architecture-flow-canvas .react-flow { background: radial-gradient(circle at center, color-mix(in srgb, var(--accent) 8%, var(--surface)), var(--surface) 70%); }
+.architecture-flow-canvas .react-flow__edge-label { fill: var(--text-muted); }
+.architecture-flow-canvas .react-flow__node { width: 11.5rem; padding: 0; border: 1px solid var(--border); border-radius: .2rem; background: color-mix(in srgb, var(--surface) 93%, var(--accent)); color: var(--text); box-shadow: 0 12px 28px rgb(0 0 0 / .08); text-align: left; }
+.architecture-flow-canvas .react-flow__node.selected { border-color: var(--accent); box-shadow: 0 0 0 2px color-mix(in srgb, var(--accent) 28%, transparent), 0 18px 38px rgb(0 0 0 / .14); }
+.architecture-node-content { display: grid; gap: .35rem; padding: .85rem; }
+.architecture-node-content small { color: var(--accent-strong); font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace; font-size: .58rem; letter-spacing: .09em; text-transform: uppercase; }
+.architecture-node-content strong { font-size: .83rem; line-height: 1.25; }
+.architecture-node--source, .architecture-node--delivery { border-color: var(--accent) !important; }
+.architecture-flow-canvas .react-flow__controls { overflow: hidden; border: 1px solid var(--border); border-radius: .3rem; box-shadow: none; }
+.architecture-flow-canvas .react-flow__controls-button { border-color: var(--border); background: var(--surface); color: var(--text); fill: currentColor; }
+.architecture-flow-canvas .react-flow__background line { stroke: var(--border); }
+.architecture-selection { display: grid; grid-template-columns: 7rem 1fr; gap: .35rem 1.5rem; min-height: 7rem; padding: 1.2rem 1.5rem; border-top: 1px solid var(--border); background: var(--surface-muted); }
+.architecture-selection > span { grid-row: 1 / span 2; color: var(--accent-strong); font-size: .68rem; font-weight: 750; letter-spacing: .1em; text-transform: uppercase; }
+.architecture-selection h3 { margin: 0; font-family: var(--font-source-sans), Arial, sans-serif; font-size: 1.1rem; }
+.architecture-selection p { margin: 0; color: var(--text-muted); line-height: 1.5; }
+.architecture-text-equivalent { margin-top: 1rem; border-top: 1px solid var(--border); border-bottom: 1px solid var(--border); }
+.architecture-text-equivalent summary { padding: 1rem 0; color: var(--accent-strong); font-weight: 750; cursor: pointer; }
+.architecture-text-equivalent ol { display: grid; grid-template-columns: repeat(2, 1fr); gap: 0 2rem; padding: 0 0 1.5rem 1.4rem; }
+.architecture-text-equivalent li { padding: .8rem 0; color: var(--text-muted); }
+.architecture-text-equivalent li strong, .architecture-text-equivalent li span { display: block; }
+.architecture-text-equivalent li strong { color: var(--text); }
+.architecture-text-equivalent li span { margin-top: .25rem; font-size: .88rem; line-height: 1.45; }
+
+@media (max-width: 900px) {
+  .dossier-hero-copy { grid-column: 1 / span 8; }
+  .dossier-facts { grid-column: 9 / -1; }
+  .dossier-layout { display: block; }
+  .dossier-toc { z-index: 10; top: 4.5rem; display: flex; align-items: center; overflow-x: auto; margin-bottom: 1rem; padding: .75rem 0; background: color-mix(in srgb, var(--canvas) 94%, transparent); backdrop-filter: blur(12px); }
+  .dossier-toc > p { display: none; }
+  .dossier-toc ol { display: flex; gap: 1.25rem; width: max-content; }
+  .dossier-toc li + li { margin: 0; }
+  .dossier-toc a { display: block; white-space: nowrap; }
+  .dossier-toc a span { margin-right: .35rem; }
+}
+
+@media (max-width: 700px) {
+  .work-page, .dossier-breadcrumb, .dossier-hero, .dossier-layout { width: min(100% - 1.25rem, 78rem); }
+  .work-card { display: block; }
+  .work-card > p:not(.project-card-label) { margin-top: 1rem; }
+  .dossier-hero { display: block; }
+  .dossier-facts { margin-top: 3rem; }
+  .dossier-outcomes { grid-template-columns: 1fr; }
+  .dossier-outcomes article { min-height: 10rem; border-right: 0; border-bottom: 1px solid var(--border); }
+  .dossier-outcomes article:last-child { border-bottom: 0; }
+  .evidence-boundary { grid-template-columns: 1fr; margin-top: 1rem; }
+  .dossier-narrative, .dossier-narrative--context, .dossier-narrative--decisions, .dossier-narrative--outcome { display: block; margin-left: 0; }
+  .dossier-narrative > div + div, .dossier-narrative--context > div + div, .dossier-narrative--decisions > div + div, .dossier-narrative--outcome > div + div { margin-top: 1.5rem; }
+  .dossier-narrative--context > div { padding-top: 1.2rem; }
+  .architecture-map-placeholder, .architecture-flow-canvas { height: 31rem; }
+  .architecture-selection { display: block; }
+  .architecture-selection > span { display: block; margin-bottom: .5rem; }
+  .architecture-text-equivalent ol { grid-template-columns: 1fr; }
+}
 
 .experience-page { width: min(100% - 2rem, 72rem); margin: 0 auto; padding: clamp(4rem, 8vw, 7rem) 0; }
 .experience-hero { max-width: 56rem; padding-bottom: clamp(3rem, 6vw, 5rem); border-bottom: 1px solid var(--border); }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -80,12 +80,12 @@ export default function HomePage() {
                   <Link href={`/work/${project.slug}`}>Open engineering dossier <span aria-hidden="true">↗</span></Link>
                 </div>
                 <div className="selected-work-evidence">
-                  <p>{caseStudy?.outcomes[0]}</p>
+                  <p>{caseStudy ? `${caseStudy.outcomes[0]?.value} ${caseStudy.outcomes[0]?.label}` : null}</p>
                   <ul aria-label={`${project.title} technologies`}>
                     {project.technologies.slice(0, 5).map((technology) => <li key={technology}>{technology}</li>)}
                   </ul>
                   <span className="selected-work-flow" aria-hidden="true">
-                    {caseStudy?.flow.slice(0, 4).map((step) => <i key={step} title={step} />)}
+                    {caseStudy?.architecture.nodes.slice(0, 4).map((node) => <i key={node.id} title={node.label} />)}
                   </span>
                 </div>
               </article>

--- a/src/app/work/[slug]/page.tsx
+++ b/src/app/work/[slug]/page.tsx
@@ -1,24 +1,262 @@
 import type { Metadata } from 'next';
 import Link from 'next/link';
 import { notFound } from 'next/navigation';
-import { caseStudies, caseStudySectionKeys } from '@/content/caseStudies';
+
 import { JsonLd } from '@/components/seo/JsonLd';
+import { ArchitectureMap } from '@/components/work/ArchitectureMap';
+import { caseStudies, type CaseStudy, type CaseStudySectionKey } from '@/content/caseStudies';
+import { portfolioContent } from '@/content/portfolio';
 
 type Props = { params: Promise<{ slug: string }> };
-const labels = { context:'Context', problem:'Problem', constraints:'Constraints', role:'Role', architecture:'Architecture', requestDataFlow:'Request and data flow', decisions:'Decisions', alternatives:'Alternatives considered', tradeOffs:'Trade-offs', reliabilitySecurityAccessibility:'Reliability, security, and accessibility', testingDelivery:'Testing and delivery', outcome:'Outcome', nextImprovements:'Next improvements', evidence:'Evidence' } as const;
 
-export function generateStaticParams() { return caseStudies.map(({ slug }) => ({ slug })); }
-export async function generateMetadata({ params }: Props): Promise<Metadata> { const { slug } = await params; const item = caseStudies.find((entry) => entry.slug === slug); return item ? { title: item.title, description: item.summary, alternates: { canonical: `/work/${slug}` } } : { title: 'Case study not found' }; }
+type Chapter = {
+  id: string;
+  label: string;
+  fields: Array<{ key: CaseStudySectionKey; label: string }>;
+};
+
+const chapters: Chapter[] = [
+  {
+    id: 'context',
+    label: 'Context and constraints',
+    fields: [
+      { key: 'context', label: 'Context' },
+      { key: 'problem', label: 'Problem' },
+      { key: 'constraints', label: 'Constraints' },
+    ],
+  },
+  {
+    id: 'role',
+    label: 'Role and responsibilities',
+    fields: [{ key: 'role', label: 'Role and responsibilities' }],
+  },
+  {
+    id: 'architecture',
+    label: 'Architecture and data flow',
+    fields: [
+      { key: 'architecture', label: 'Architecture' },
+      { key: 'requestDataFlow', label: 'Request and data flow' },
+    ],
+  },
+  {
+    id: 'decisions',
+    label: 'Decisions and trade-offs',
+    fields: [
+      { key: 'decisions', label: 'Decision' },
+      { key: 'alternatives', label: 'Alternative considered' },
+      { key: 'tradeOffs', label: 'Trade-off' },
+    ],
+  },
+  {
+    id: 'reliability',
+    label: 'Reliability and accessibility',
+    fields: [{ key: 'reliabilitySecurityAccessibility', label: 'Reliability, security, and accessibility' }],
+  },
+  {
+    id: 'testing',
+    label: 'Testing and delivery',
+    fields: [{ key: 'testingDelivery', label: 'Testing and delivery' }],
+  },
+  {
+    id: 'outcome',
+    label: 'Outcome and evidence',
+    fields: [
+      { key: 'outcome', label: 'Outcome' },
+      { key: 'evidence', label: 'Evidence' },
+      { key: 'nextImprovements', label: 'Next improvement' },
+    ],
+  },
+];
+
+export function generateStaticParams() {
+  return caseStudies.map(({ slug }) => ({ slug }));
+}
+
+export async function generateMetadata({ params }: Props): Promise<Metadata> {
+  const { slug } = await params;
+  const item = caseStudies.find((entry) => entry.slug === slug);
+  return item
+    ? { title: item.title, description: item.summary, alternates: { canonical: `/work/${slug}` } }
+    : { title: 'Case study not found' };
+}
+
+function NarrativeBlocks({
+  item,
+  chapter,
+}: {
+  item: CaseStudy;
+  chapter: Chapter;
+}) {
+  return (
+    <div className={`dossier-narrative dossier-narrative--${chapter.id}`}>
+      {chapter.fields.map(({ key, label }) => {
+        const value = item.sections[key];
+        return value ? (
+          <div key={key}>
+            <h3>{label}</h3>
+            <p>{value}</p>
+          </div>
+        ) : null;
+      })}
+    </div>
+  );
+}
+
+function ArchitectureText({ item }: { item: CaseStudy }) {
+  const outgoing = new Map(
+    item.architecture.nodes.map((node) => [
+      node.id,
+      item.architecture.edges.filter((edge) => edge.source === node.id),
+    ]),
+  );
+  const nodesById = new Map(item.architecture.nodes.map((node) => [node.id, node]));
+
+  return (
+    <details className="architecture-text-equivalent" open>
+      <summary>Read the architecture as text</summary>
+      <ol>
+        {item.architecture.nodes.map((node) => (
+          <li key={node.id}>
+            <strong>{node.label}</strong>
+            {node.detail ? <span>{node.detail}</span> : null}
+            {(outgoing.get(node.id) ?? []).length > 0 ? (
+              <span>
+                Connects to{' '}
+                {(outgoing.get(node.id) ?? [])
+                  .map((edge) => `${nodesById.get(edge.target)?.label}${edge.label ? ` (${edge.label})` : ''}`)
+                  .join(', ')}.
+              </span>
+            ) : null}
+          </li>
+        ))}
+      </ol>
+    </details>
+  );
+}
 
 export default async function CaseStudyPage({ params }: Props) {
-  const { slug } = await params; const item = caseStudies.find((entry) => entry.slug === slug); if (!item) notFound();
-  return <article className="case-study">
-    <JsonLd data={{ '@context': 'https://schema.org', '@type': 'CreativeWork', name: item.title, description: item.summary, url: `https://ssohail.com/work/${item.slug}`, author: { '@type': 'Person', name: 'Saqib Sohail' }, keywords: item.capabilities.join(', ') }} />
-    <nav aria-label="Breadcrumb"><Link href="/work">Work</Link><span aria-hidden="true"> / </span><span>{item.title}</span></nav>
-    <header><p className="eyebrow">{item.visibility === 'private-redacted' ? 'Private / redacted case study' : 'Public case study'}</p><h1>{item.title}</h1><p>{item.summary}</p></header>
-    <dl className="case-study-facts"><div><dt>Capabilities</dt><dd>{item.capabilities.join(' · ')}</dd></div><div><dt>Stack</dt><dd>{item.stack.join(' · ')}</dd></div></dl>
-    <figure className="architecture-flow"><figcaption>System flow</figcaption><ol>{item.flow.map((step) => <li key={step}>{step}</li>)}</ol><p className="sr-only">{item.flow.join(' then ')}</p></figure>
-    <div className="case-study-body">{caseStudySectionKeys.map((key) => item.sections[key] ? <section key={key}><h2>{labels[key]}</h2><p>{item.sections[key]}</p></section> : null)}</div>
-    {item.outcomes.length > 0 && <section className="case-study-outcomes"><h2>Outcomes at a glance</h2><ul>{item.outcomes.map((outcome) => <li key={outcome}>{outcome}</li>)}</ul></section>}
-  </article>;
+  const { slug } = await params;
+  const item = caseStudies.find((entry) => entry.slug === slug);
+  if (!item) notFound();
+
+  const evidenceRecords = item.evidenceRefs
+    .map((id) => portfolioContent.evidence.find((evidence) => evidence.id === id))
+    .filter(Boolean);
+  const publicEvidence = evidenceRecords.find((evidence) => evidence?.url);
+  const availableChapters = chapters.filter((chapter) =>
+    chapter.fields.some(({ key }) => Boolean(item.sections[key])),
+  );
+
+  return (
+    <article className="case-study dossier">
+      <JsonLd
+        data={{
+          '@context': 'https://schema.org',
+          '@type': 'CreativeWork',
+          name: item.title,
+          description: item.summary,
+          url: `https://ssohail.com/work/${item.slug}`,
+          author: { '@type': 'Person', name: 'Saqib Sohail' },
+          keywords: item.capabilities.join(', '),
+        }}
+      />
+
+      <nav className="dossier-breadcrumb" aria-label="Breadcrumb">
+        <Link href="/work">Work</Link>
+        <span aria-hidden="true"> / </span>
+        <span>{item.title}</span>
+      </nav>
+
+      <header className="dossier-hero">
+        <div className="dossier-hero-copy">
+          <p className="eyebrow">{item.visibility === 'private-redacted' ? 'Private / redacted case study' : 'Public case study'}</p>
+          <h1>{item.title}</h1>
+          <p>{item.summary}</p>
+          {publicEvidence?.url ? (
+            <a className="dossier-evidence-link" href={publicEvidence.url} target="_blank" rel="noreferrer">
+              View public repository <span aria-hidden="true">↗</span>
+            </a>
+          ) : null}
+        </div>
+
+        <dl className="dossier-facts">
+          <div>
+            <dt>Status</dt>
+            <dd>Published</dd>
+          </div>
+          <div>
+            <dt>Capabilities</dt>
+            <dd>{item.capabilities.join(' · ')}</dd>
+          </div>
+          <div>
+            <dt>Stack</dt>
+            <dd>{item.stack.join(' · ')}</dd>
+          </div>
+          <div>
+            <dt>Evidence</dt>
+            <dd>{publicEvidence?.url ? 'Public repository' : 'Approved portfolio brief'}</dd>
+          </div>
+        </dl>
+
+        <section className="dossier-outcomes" aria-label="Outcomes">
+          {item.outcomes.map((outcome) => (
+            <article key={`${outcome.value}-${outcome.label}`}>
+              <strong>{outcome.value}</strong>
+              <h2>{outcome.label}</h2>
+              {outcome.context ? <p>{outcome.context}</p> : null}
+            </article>
+          ))}
+        </section>
+
+        {item.evidenceBoundary ? (
+          <aside className="evidence-boundary" aria-label="Evidence boundary">
+            <span aria-hidden="true">BOUNDARY</span>
+            <p>{item.evidenceBoundary}</p>
+          </aside>
+        ) : null}
+      </header>
+
+      <div className="dossier-layout">
+        <aside className="dossier-toc">
+          <p>On this page</p>
+          <nav aria-label="Case study sections">
+            <ol>
+              {availableChapters.map((chapter, index) => (
+                <li key={chapter.id}>
+                  <a href={`#${chapter.id}`}>
+                    <span>{String(index + 1).padStart(2, '0')}</span>
+                    {chapter.label}
+                  </a>
+                </li>
+              ))}
+            </ol>
+          </nav>
+        </aside>
+
+        <div className="dossier-content">
+          {availableChapters.map((chapter, index) => (
+            <section key={chapter.id} id={chapter.id} className={`dossier-chapter dossier-chapter--${chapter.id}`}>
+              <header>
+                <span>{String(index + 1).padStart(2, '0')}</span>
+                <h2>{chapter.label}</h2>
+              </header>
+
+              {chapter.id === 'architecture' ? (
+                <>
+                  <NarrativeBlocks item={item} chapter={chapter} />
+                  <figure className="dossier-architecture">
+                    <figcaption>Interactive system map</figcaption>
+                    <ArchitectureMap nodes={item.architecture.nodes} edges={item.architecture.edges} title={item.title} />
+                    <ArchitectureText item={item} />
+                  </figure>
+                </>
+              ) : (
+                <NarrativeBlocks item={item} chapter={chapter} />
+              )}
+            </section>
+          ))}
+        </div>
+      </div>
+    </article>
+  );
 }

--- a/src/components/work/ArchitectureFlowCanvas.tsx
+++ b/src/components/work/ArchitectureFlowCanvas.tsx
@@ -1,0 +1,145 @@
+'use client';
+
+import {
+  Background,
+  BackgroundVariant,
+  Controls,
+  MarkerType,
+  ReactFlow,
+  type Edge,
+  type Node,
+  type NodeMouseHandler,
+} from '@xyflow/react';
+import '@xyflow/react/dist/style.css';
+import { useMemo, useState } from 'react';
+
+import type { ArchitectureEdge, ArchitectureNode } from '@/content/caseStudies';
+
+type FlowNodeData = {
+  label: React.ReactNode;
+  source: ArchitectureNode;
+};
+
+function buildLayout(nodes: readonly ArchitectureNode[], edges: readonly ArchitectureEdge[]) {
+  const depth = new Map<string, number>();
+  nodes.filter((node) => node.kind === 'source').forEach((node) => depth.set(node.id, 0));
+  if (depth.size === 0 && nodes[0]) depth.set(nodes[0].id, 0);
+
+  for (let pass = 0; pass < nodes.length; pass += 1) {
+    for (const edge of edges) {
+      const sourceDepth = depth.get(edge.source);
+      if (sourceDepth !== undefined && depth.get(edge.target) === undefined) {
+        depth.set(edge.target, sourceDepth + 1);
+      }
+    }
+  }
+  nodes.forEach((node, index) => {
+    if (depth.get(node.id) === undefined) depth.set(node.id, index);
+  });
+
+  const layers = new Map<number, ArchitectureNode[]>();
+  nodes.forEach((node) => {
+    const layer = depth.get(node.id) ?? 0;
+    layers.set(layer, [...(layers.get(layer) ?? []), node]);
+  });
+
+  const flowNodes: Node<FlowNodeData>[] = [];
+  [...layers.entries()].forEach(([layer, layerNodes]) => {
+    const rowGroup = Math.floor(layer / 4);
+    const localColumn = layer % 4;
+    const visualColumn = rowGroup % 2 === 0 ? localColumn : 3 - localColumn;
+    layerNodes.forEach((node, row) => {
+      flowNodes.push({
+        id: node.id,
+        position: {
+          x: visualColumn * 245,
+          y: rowGroup * 240 + row * 118 - ((layerNodes.length - 1) * 118) / 2,
+        },
+        data: {
+          source: node,
+          label: (
+            <span className="architecture-node-content">
+              <small>{node.kind}</small>
+              <strong>{node.label}</strong>
+            </span>
+          ),
+        },
+        className: `architecture-node architecture-node--${node.kind}`,
+        ariaLabel: `${node.label}, ${node.kind}${node.detail ? `: ${node.detail}` : ''}`,
+        draggable: false,
+        connectable: false,
+        selectable: true,
+      });
+    });
+  });
+
+  const flowEdges: Edge[] = edges.map((edge, index) => ({
+    id: `${edge.source}-${edge.target}-${index}`,
+    source: edge.source,
+    target: edge.target,
+    label: edge.label,
+    type: 'smoothstep',
+    markerEnd: { type: MarkerType.ArrowClosed, color: '#46bdd0' },
+    style: { stroke: '#46bdd0', strokeWidth: 1.4 },
+    labelStyle: { fill: 'currentColor', fontSize: 11 },
+  }));
+
+  return { flowNodes, flowEdges };
+}
+
+export function ArchitectureFlowCanvas({
+  nodes,
+  edges,
+  title,
+}: {
+  nodes: readonly ArchitectureNode[];
+  edges: readonly ArchitectureEdge[];
+  title: string;
+}) {
+  const { flowNodes, flowEdges } = useMemo(() => buildLayout(nodes, edges), [edges, nodes]);
+  const [selectedId, setSelectedId] = useState(nodes[0]?.id);
+  const selected = nodes.find((node) => node.id === selectedId) ?? nodes[0];
+  const handleNodeClick: NodeMouseHandler<Node<FlowNodeData>> = (_, node) => setSelectedId(node.id);
+
+  return (
+    <>
+      <div
+        className="architecture-flow-canvas"
+        role="group"
+        aria-label={`${title} interactive architecture map`}
+        onKeyDownCapture={(event) => {
+          if (event.key !== 'Enter' && event.key !== ' ') return;
+          const node = (event.target as HTMLElement).closest<HTMLElement>('.react-flow__node');
+          if (!node?.dataset.id) return;
+          event.preventDefault();
+          setSelectedId(node.dataset.id);
+        }}
+      >
+        <ReactFlow
+          nodes={flowNodes}
+          edges={flowEdges}
+          onNodeClick={handleNodeClick}
+          fitView
+          fitViewOptions={{ padding: 0.12 }}
+          minZoom={0.32}
+          maxZoom={1.5}
+          nodesDraggable={false}
+          nodesConnectable={false}
+          edgesFocusable={false}
+          panOnScroll={false}
+          proOptions={{ hideAttribution: true }}
+        >
+          <Background variant={BackgroundVariant.Lines} gap={28} size={0.65} />
+          <Controls showInteractive={false} position="bottom-right" />
+        </ReactFlow>
+      </div>
+      {selected ? (
+        <section className="architecture-selection" aria-live="polite">
+          <span>{selected.kind}</span>
+          <h3>{selected.label}</h3>
+          {selected.detail ? <p>{selected.detail}</p> : <p>This boundary is represented in the ordered architecture flow below.</p>}
+        </section>
+      ) : null}
+    </>
+  );
+}

--- a/src/components/work/ArchitectureMap.tsx
+++ b/src/components/work/ArchitectureMap.tsx
@@ -1,0 +1,52 @@
+'use client';
+
+import dynamic from 'next/dynamic';
+import { useEffect, useRef, useState } from 'react';
+
+import type { ArchitectureEdge, ArchitectureNode } from '@/content/caseStudies';
+
+const ArchitectureFlowCanvas = dynamic(
+  () => import('./ArchitectureFlowCanvas').then((module) => module.ArchitectureFlowCanvas),
+  { ssr: false },
+);
+
+export function ArchitectureMap({
+  nodes,
+  edges,
+  title,
+}: {
+  nodes: readonly ArchitectureNode[];
+  edges: readonly ArchitectureEdge[];
+  title: string;
+}) {
+  const wrapperRef = useRef<HTMLDivElement>(null);
+  const [ready, setReady] = useState(false);
+
+  useEffect(() => {
+    const element = wrapperRef.current;
+    if (!element) return;
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        if (entry.isIntersecting) {
+          setReady(true);
+          observer.disconnect();
+        }
+      },
+      { rootMargin: '240px 0px' },
+    );
+    observer.observe(element);
+    return () => observer.disconnect();
+  }, []);
+
+  return (
+    <div ref={wrapperRef} className="architecture-map" data-loaded={ready ? 'true' : 'false'}>
+      {ready ? (
+        <ArchitectureFlowCanvas nodes={nodes} edges={edges} title={title} />
+      ) : (
+        <div className="architecture-map-placeholder" aria-hidden="true">
+          {nodes.slice(0, 6).map((node) => <span key={node.id} />)}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/content/caseStudies.ts
+++ b/src/content/caseStudies.ts
@@ -1,13 +1,57 @@
 import { portfolioContent } from './portfolio';
 
 export const caseStudySectionKeys = [
-  'context', 'problem', 'constraints', 'role', 'architecture', 'requestDataFlow',
-  'decisions', 'alternatives', 'tradeOffs', 'reliabilitySecurityAccessibility',
-  'testingDelivery', 'outcome', 'nextImprovements', 'evidence',
+  'context',
+  'problem',
+  'constraints',
+  'role',
+  'architecture',
+  'requestDataFlow',
+  'decisions',
+  'alternatives',
+  'tradeOffs',
+  'reliabilitySecurityAccessibility',
+  'testingDelivery',
+  'outcome',
+  'nextImprovements',
+  'evidence',
+] as const;
+
+export const requiredCaseStudySectionKeys = [
+  'context',
+  'problem',
+  'constraints',
+  'role',
+  'architecture',
+  'requestDataFlow',
+  'decisions',
+  'tradeOffs',
+  'outcome',
+  'evidence',
 ] as const;
 
 export type CaseStudySectionKey = (typeof caseStudySectionKeys)[number];
 export type CaseStudyVisibility = 'public' | 'private-redacted';
+export type ArchitectureNodeKind = 'source' | 'interface' | 'boundary' | 'service' | 'decision' | 'data' | 'delivery';
+
+export type CaseStudyOutcome = {
+  value: string;
+  label: string;
+  context?: string;
+};
+
+export type ArchitectureNode = {
+  id: string;
+  label: string;
+  kind: ArchitectureNodeKind;
+  detail?: string;
+};
+
+export type ArchitectureEdge = {
+  source: string;
+  target: string;
+  label?: string;
+};
 
 export type CaseStudy = {
   slug: string;
@@ -17,10 +61,14 @@ export type CaseStudy = {
   status: 'published';
   capabilities: string[];
   stack: string[];
-  outcomes: string[];
+  outcomes: CaseStudyOutcome[];
   evidenceRefs: string[];
-  flow: string[];
-  sections: Record<CaseStudySectionKey, string | null>;
+  architecture: {
+    nodes: ArchitectureNode[];
+    edges: ArchitectureEdge[];
+  };
+  evidenceBoundary?: string;
+  sections: Partial<Record<CaseStudySectionKey, string>>;
 };
 
 export const caseStudies: CaseStudy[] = [
@@ -28,44 +76,98 @@ export const caseStudies: CaseStudy[] = [
     slug: 'ai-assisted-contract-workflow',
     title: 'AI-Assisted Contract Workflow',
     summary: 'A redacted workflow connecting a React/TypeScript contract editor, Django application backend, FastAPI AI service, and Stripe purchase flow.',
-    visibility: 'private-redacted', status: 'published',
+    visibility: 'private-redacted',
+    status: 'published',
     capabilities: ['Frontend architecture', 'Service integration', 'Applied AI'],
     stack: ['React', 'TypeScript', 'Django', 'FastAPI', 'RAG', 'Stripe'],
-    outcomes: ['End-to-end workflow delivered across editor, backend, AI service, and production integration.'],
+    outcomes: [
+      {
+        value: 'End to end',
+        label: 'Product workflow',
+        context: 'Editor, backend, AI service, payment, and controlled document access.',
+      },
+    ],
     evidenceRefs: ['approved-velsa'],
-    flow: ['Structured user input', 'React editor', 'Django APIs', 'FastAPI AI service', 'Contract content', 'Controlled document access'],
+    evidenceBoundary: 'This private case study describes approved system boundaries only. Company, customer, prompt, model, infrastructure, and document material remain confidential.',
+    architecture: {
+      nodes: [
+        { id: 'structured-input', label: 'Structured input', kind: 'source', detail: 'Values collected through the conversational workflow.' },
+        { id: 'react-editor', label: 'React editor', kind: 'interface', detail: 'Merge fields, inline options, and conditional clauses.' },
+        { id: 'django-api', label: 'Django APIs', kind: 'boundary', detail: 'Application state and integration boundary.' },
+        { id: 'fastapi-ai', label: 'FastAPI AI service', kind: 'service', detail: 'LLM inference and vector retrieval.' },
+        { id: 'contract-content', label: 'Contract content', kind: 'data', detail: 'Structured values populate controlled document content.' },
+        { id: 'stripe-webhooks', label: 'Stripe webhooks', kind: 'service', detail: 'Purchasing lifecycle integration.' },
+        { id: 'document-access', label: 'Controlled access', kind: 'delivery', detail: 'Purchase state controls document access.' },
+      ],
+      edges: [
+        { source: 'structured-input', target: 'react-editor' },
+        { source: 'react-editor', target: 'django-api', label: 'validated request' },
+        { source: 'django-api', target: 'fastapi-ai', label: 'service request' },
+        { source: 'fastapi-ai', target: 'contract-content', label: 'retrieved and generated content' },
+        { source: 'contract-content', target: 'react-editor', label: 'populate editor' },
+        { source: 'django-api', target: 'stripe-webhooks', label: 'purchase state' },
+        { source: 'stripe-webhooks', target: 'document-access' },
+      ],
+    },
     sections: {
       context: 'The product needed a browser-based workflow for collecting structured input and producing contract content while keeping purchase and document access inside the application.',
       problem: 'The interface, application backend, AI capability, and payment lifecycle needed to work as one understandable product flow.',
-      constraints: 'Company, customer, prompt, model, infrastructure, and document details remain confidential. This case study intentionally describes only the approved system boundaries.',
+      constraints: 'Confidential product and customer material sets the public evidence boundary for this account.',
       role: 'Designed the application flow and service integration and owned delivery across the editor, Django backend, FastAPI service, and production integration.',
       architecture: 'A React/TypeScript editor communicated through Django APIs. Django integrated with a separate FastAPI service for LLM inference and vector retrieval, while Stripe webhooks controlled purchasing and document access.',
       requestDataFlow: 'The conversational interface collected structured values, sent them through backend APIs, and populated merge fields, inline options, and conditional clauses in contract content.',
       decisions: 'The AI capability was separated behind a FastAPI service and integrated through the application backend instead of being coupled directly to the browser editor.',
-      alternatives: null,
       tradeOffs: 'Separating the AI service added an integration boundary but kept the editor and application backend responsible for predictable product state.',
-      reliabilitySecurityAccessibility: 'Payment webhooks and controlled document access were part of the approved flow. Further security, reliability, and accessibility claims are omitted because public evidence is unavailable.',
-      testingDelivery: 'Production integration is approved; detailed test coverage and deployment infrastructure are not publicly documented.',
+      reliabilitySecurityAccessibility: 'Stripe webhooks and controlled document access kept purchase state inside the application workflow.',
       outcome: 'The delivered workflow connected structured conversation, contract editing, AI-assisted content population, payment, and controlled document access.',
-      nextImprovements: null,
-      evidence: 'Approved portfolio brief for the Velsa Technologies role. No confidential repository or customer material is linked.',
+      evidence: 'Approved portfolio brief for the Velsa Technologies role.',
     },
   },
   {
-    slug: 'jobs-tracker-bot', title: 'Jobs Tracker Bot',
+    slug: 'jobs-tracker-bot',
+    title: 'Jobs Tracker Bot',
     summary: 'An async Python job aggregation pipeline with provider adapters, deterministic eligibility rules, scoring, deduplication, persistence, and alert routing.',
-    visibility: 'public', status: 'published',
+    visibility: 'public',
+    status: 'published',
     capabilities: ['Backend pipeline', 'Automation', 'Testing and delivery'],
     stack: ['Python', 'Docker', 'GitHub Actions', 'Discord', 'Telegram'],
-    outcomes: ['520+ automated tests.', 'Scheduled deployment to Oracle Cloud through GitHub Actions.'],
+    outcomes: [
+      { value: '520+', label: 'Automated tests', context: 'Deterministic pipeline and adapter coverage.' },
+      { value: 'GitHub Actions → Oracle Cloud', label: 'Scheduled delivery', context: 'Containerised deployment and recurring execution.' },
+    ],
     evidenceRefs: ['approved-jobs-tracker'],
-    flow: ['ATS/provider adapters', 'Normalisation', 'Eligibility filters', 'Scoring', 'Deduplication and persistence', 'Immediate or digest alerts'],
+    architecture: {
+      nodes: [
+        { id: 'ats-adapters', label: 'ATS adapters', kind: 'source', detail: 'Async source-specific acquisition.' },
+        { id: 'provider-adapters', label: 'Provider adapters', kind: 'source', detail: 'Source behaviour remains behind adapter boundaries.' },
+        { id: 'normalisation', label: 'Normalisation', kind: 'boundary', detail: 'Provider payloads become a consistent job model.' },
+        { id: 'filters', label: 'Deterministic filters', kind: 'decision', detail: 'Explicit rules run before scoring.' },
+        { id: 'eligibility', label: 'Eligibility score', kind: 'decision', detail: 'Germany and Berlin suitability remains independent.' },
+        { id: 'cv-fit', label: 'CV-fit score', kind: 'decision', detail: 'Role relevance remains a separate dimension.' },
+        { id: 'deduplication', label: 'Deduplication', kind: 'service', detail: 'Previously processed roles are identified.' },
+        { id: 'persistence', label: 'Persistence', kind: 'data', detail: 'Decisions and notification state survive scheduled runs.' },
+        { id: 'immediate-alerts', label: 'Immediate Discord / Telegram', kind: 'delivery', detail: 'New high-priority matches route immediately.' },
+        { id: 'digest-alerts', label: 'Digest Discord / Telegram', kind: 'delivery', detail: 'Eligible matches can be grouped for digest delivery.' },
+      ],
+      edges: [
+        { source: 'ats-adapters', target: 'normalisation' },
+        { source: 'provider-adapters', target: 'normalisation' },
+        { source: 'normalisation', target: 'filters' },
+        { source: 'filters', target: 'eligibility' },
+        { source: 'filters', target: 'cv-fit' },
+        { source: 'eligibility', target: 'deduplication' },
+        { source: 'cv-fit', target: 'deduplication' },
+        { source: 'deduplication', target: 'persistence' },
+        { source: 'persistence', target: 'immediate-alerts' },
+        { source: 'persistence', target: 'digest-alerts' },
+      ],
+    },
     sections: {
       context: 'Job sources expose different APIs and payloads, while useful alerts require consistent eligibility and relevance decisions.',
       problem: 'Aggregate suitable roles without turning source-specific behaviour into one fragile scraper or sending repetitive, low-value notifications.',
-      constraints: 'Provider availability and schemas vary. Germany/Berlin eligibility and CV-fit scoring need to remain separate and deterministic.',
+      constraints: 'Provider availability and schemas vary. Germany and Berlin eligibility and CV-fit scoring need to remain separate and deterministic.',
       role: 'Designed and implemented the aggregation, filtering, scoring, persistence, notification, scheduling, health, concurrency, and delivery pipeline.',
-      architecture: 'Async provider adapters feed a normalised pipeline. Deterministic filters run before separate eligibility and CV-fit scores, followed by deduplication, persistence, and notification routing.',
+      architecture: 'Async provider adapters fan into a normalised pipeline. Deterministic filters precede separate eligibility and CV-fit scores, followed by deduplication, persistence, and notification routing.',
       requestDataFlow: 'Scheduled runs fetch provider data concurrently, normalise roles, apply filters and scores, persist decisions, and route new matches to immediate or digest Discord and Telegram adapters.',
       decisions: 'Direct provider adapters, deterministic filters, separate score dimensions, and persistence make behaviour reviewable and prevent duplicate alerts.',
       alternatives: 'A single combined score would be simpler, but it would blur location eligibility and role relevance into one opaque decision.',
@@ -73,45 +175,86 @@ export const caseStudies: CaseStudy[] = [
       reliabilitySecurityAccessibility: 'Concurrency control, health reporting, deduplication, and persisted state protect scheduled runs. Bot output remains text-based across both notification adapters.',
       testingDelivery: 'The public project includes 520+ tests, Docker, scheduling, health checks, concurrency control, and GitHub Actions deployment to Oracle Cloud.',
       outcome: 'The pipeline turns heterogeneous provider data into deterministic, deduplicated alerts with separate immediate and digest delivery paths.',
-      nextImprovements: null,
-      evidence: 'Public repository: https://github.com/saqibroy/jobs-tracker-bot',
+      evidence: 'The public Jobs Tracker Bot repository contains the implementation and delivery configuration.',
     },
   },
   {
-    slug: 'tactical-tech-platform-modernisation', title: 'Tactical Tech Platform Modernisation',
+    slug: 'tactical-tech-platform-modernisation',
+    title: 'Tactical Tech Platform Modernisation',
     summary: 'Frontend delivery and modernisation across public-facing platforms used by researchers, educators, international users, and civil-society organisations.',
-    visibility: 'private-redacted', status: 'published',
+    visibility: 'private-redacted',
+    status: 'published',
     capabilities: ['Frontend modernisation', 'Performance', 'Content architecture'],
     stack: ['React', 'Vue.js', 'Next.js', 'Nuxt.js', 'TypeScript', 'Decap CMS'],
-    outcomes: ['3 legacy applications migrated.', '30% faster initial loads.', '50%+ faster editorial workflows.'],
+    outcomes: [
+      { value: '3', label: 'Legacy applications migrated', context: 'Next.js and Nuxt.js modernisation.' },
+      { value: '30%', label: 'Faster initial loads', context: 'Code splitting, lazy loading, and frontend optimisation.' },
+      { value: '50%+', label: 'Faster editorial workflows', context: 'Refactored Decap CMS content architecture.' },
+    ],
     evidenceRefs: ['approved-tactical-tech'],
-    flow: ['Editorial content', 'Decap CMS', 'Next.js or Nuxt.js application', 'Optimised frontend delivery', 'Public audiences'],
+    evidenceBoundary: 'This account describes Saqib’s approved contribution scope and does not attribute organisation-wide reach or sole ownership.',
+    architecture: {
+      nodes: [
+        { id: 'editorial-content', label: 'Editorial content', kind: 'source' },
+        { id: 'decap-cms', label: 'Decap CMS', kind: 'interface', detail: 'Structured editorial workflows.' },
+        { id: 'content-model', label: 'Content architecture', kind: 'data', detail: 'Refactored content structures.' },
+        { id: 'applications', label: 'Next.js / Nuxt.js apps', kind: 'service', detail: 'Modernised frontend applications.' },
+        { id: 'optimised-delivery', label: 'Optimised delivery', kind: 'boundary', detail: 'Code splitting, lazy loading, and frontend optimisation.' },
+        { id: 'public-audiences', label: 'Public audiences', kind: 'delivery' },
+      ],
+      edges: [
+        { source: 'editorial-content', target: 'decap-cms' },
+        { source: 'decap-cms', target: 'content-model' },
+        { source: 'content-model', target: 'applications' },
+        { source: 'applications', target: 'optimised-delivery' },
+        { source: 'optimised-delivery', target: 'public-audiences' },
+      ],
+    },
     sections: {
       context: 'Multiple public-facing platforms served research, education, and civil-society audiences with different content and product needs.',
       problem: 'Legacy frontend applications and content structures made delivery, performance, and editorial work harder to sustain.',
-      constraints: 'The work spanned several platforms and cross-functional teams. This account avoids attributing organisation-wide reach or sole ownership.',
+      constraints: 'The work spanned several platforms and cross-functional teams. This account keeps the approved contribution scope explicit.',
       role: 'As Front-End Developer, owned frontend delivery and modernisation decisions across 5+ public-facing platforms and partnered with product, design, research, and editorial teams.',
       architecture: 'Three legacy applications were migrated to Next.js or Nuxt.js. Decap CMS content architecture supported editorial workflows across the frontend systems.',
       requestDataFlow: 'Editors managed structured content through Decap CMS; frontend applications transformed and delivered that content to public users.',
       decisions: 'Framework migration, code splitting, lazy loading, frontend optimisation, and content-model refactoring addressed maintainability, delivery, and performance together.',
-      alternatives: null,
       tradeOffs: 'Incremental modernisation preserved ongoing publishing while requiring old and new application structures to coexist during migration.',
-      reliabilitySecurityAccessibility: 'The work contributed to WCAG 2.1 AA. Stronger accessibility or security claims are intentionally omitted.',
-      testingDelivery: 'Detailed test and deployment claims are not included because they are not part of the approved public facts.',
+      reliabilitySecurityAccessibility: 'The work contributed to WCAG 2.1 AA across the approved frontend contribution scope.',
       outcome: 'The work migrated three legacy applications, reduced initial load times by 30%, and reduced editorial workflow time by more than 50%.',
-      nextImprovements: null,
       evidence: 'Approved portfolio brief for the Tactical Tech role and contribution scope.',
     },
   },
   {
-    slug: 'web-crawler-dashboard', title: 'Web Crawler Dashboard',
+    slug: 'web-crawler-dashboard',
+    title: 'Web Crawler Dashboard',
     summary: 'A React/TypeScript dashboard backed by Go/Gin and MySQL for URL analysis, crawl lifecycle management, search, filters, and bulk actions.',
-    visibility: 'public', status: 'published',
+    visibility: 'public',
+    status: 'published',
     capabilities: ['Frontend product UI', 'API integration', 'Data lifecycle'],
     stack: ['React', 'TypeScript', 'Go', 'Gin', 'GORM', 'MySQL', 'Docker'],
-    outcomes: ['Authenticated crawl-management workflow with automated frontend tests.'],
+    outcomes: [
+      { value: 'Authenticated', label: 'Crawl-management workflow', context: 'Search, filters, bulk actions, and lifecycle state.' },
+      { value: 'Automated', label: 'Frontend tests', context: 'Public project delivery evidence.' },
+    ],
     evidenceRefs: ['approved-web-crawler'],
-    flow: ['Authenticated user', 'React dashboard', 'Go/Gin API', 'GORM', 'MySQL', 'Crawl status lifecycle'],
+    architecture: {
+      nodes: [
+        { id: 'authenticated-user', label: 'Authenticated user', kind: 'source' },
+        { id: 'react-dashboard', label: 'React dashboard', kind: 'interface', detail: 'Search, filters, bulk actions, and lifecycle state.' },
+        { id: 'gin-api', label: 'Go / Gin API', kind: 'boundary', detail: 'JWT-protected REST boundary.' },
+        { id: 'crawl-lifecycle', label: 'Crawl lifecycle', kind: 'service', detail: 'URL analysis and explicit crawl states.' },
+        { id: 'gorm', label: 'GORM', kind: 'data' },
+        { id: 'mysql', label: 'MySQL', kind: 'data' },
+      ],
+      edges: [
+        { source: 'authenticated-user', target: 'react-dashboard' },
+        { source: 'react-dashboard', target: 'gin-api', label: 'authenticated actions' },
+        { source: 'gin-api', target: 'crawl-lifecycle' },
+        { source: 'crawl-lifecycle', target: 'gorm' },
+        { source: 'gorm', target: 'mysql' },
+        { source: 'crawl-lifecycle', target: 'react-dashboard', label: 'updated status' },
+      ],
+    },
     sections: {
       context: 'URL analysis produces records that need to be searched, filtered, monitored, and managed through a clear lifecycle.',
       problem: 'Provide an authenticated interface for starting and managing crawl work without losing visibility into record state or bulk operations.',
@@ -120,27 +263,64 @@ export const caseStudies: CaseStudy[] = [
       architecture: 'A React/TypeScript dashboard communicates with a Go/Gin REST API. GORM maps application data to MySQL, with JWT authentication at the API boundary.',
       requestDataFlow: 'Authenticated actions move from dashboard controls to API handlers and persisted crawl records; updated status is returned to searchable and filterable views.',
       decisions: 'Explicit crawl states, bulk actions, search, and filters make long-running URL analysis manageable from one dashboard.',
-      alternatives: null,
       tradeOffs: 'A separate Go API and React client require two delivery surfaces but keep UI state and backend persistence responsibilities clear.',
-      reliabilitySecurityAccessibility: 'JWT authentication and a defined crawl-status lifecycle are supported by public evidence. Stronger security and accessibility claims are omitted.',
+      reliabilitySecurityAccessibility: 'JWT authentication and a defined crawl-status lifecycle are supported by the public implementation.',
       testingDelivery: 'The project includes Docker setup and automated frontend tests.',
       outcome: 'The application supports authenticated URL analysis, search, filters, bulk actions, and crawl lifecycle management.',
-      nextImprovements: null,
-      evidence: 'Public repository: https://github.com/saqibroy/web-crawler-dashboard',
+      evidence: 'The public Web Crawler Dashboard repository contains the application implementation.',
     },
   },
 ];
 
+const stalePublicCopy = /\b(?:under review|follow later|return later|not publicly documented|details? (?:are|is) (?:omitted|unavailable))\b/i;
+
 export function validateCaseStudies(items: readonly CaseStudy[] = caseStudies) {
   const slugs = new Set<string>();
-  const evidence = new Set(portfolioContent.evidence.filter(({ status }) => status !== 'needs-review').map(({ id }) => id));
+  const evidence = new Set(
+    portfolioContent.evidence
+      .filter(({ status }) => status !== 'needs-review')
+      .map(({ id }) => id),
+  );
+
   for (const item of items) {
-    if (!/^[a-z0-9]+(?:-[a-z0-9]+)*$/.test(item.slug) || slugs.has(item.slug)) throw new Error(`Invalid or duplicate case-study slug: ${item.slug}`);
+    if (!/^[a-z0-9]+(?:-[a-z0-9]+)*$/.test(item.slug) || slugs.has(item.slug)) {
+      throw new Error(`Invalid or duplicate case-study slug: ${item.slug}`);
+    }
     slugs.add(item.slug);
-    if (!item.title || !item.summary || item.stack.length === 0 || item.capabilities.length === 0 || item.flow.length < 3) throw new Error(`Incomplete case study: ${item.slug}`);
-    if (!caseStudySectionKeys.every((key) => key in item.sections)) throw new Error(`Missing required section in ${item.slug}`);
-    if (!item.evidenceRefs.every((id) => evidence.has(id))) throw new Error(`Unapproved evidence in ${item.slug}`);
+
+    if (!item.title || !item.summary || item.stack.length === 0 || item.capabilities.length === 0) {
+      throw new Error(`Incomplete case study: ${item.slug}`);
+    }
+    if (!requiredCaseStudySectionKeys.every((key) => item.sections[key]?.trim())) {
+      throw new Error(`Missing required case-study section in ${item.slug}`);
+    }
+    if (item.sections.nextImprovements !== undefined && !item.sections.nextImprovements.trim()) {
+      throw new Error(`Empty next-improvements section in ${item.slug}`);
+    }
+    if (!item.evidenceRefs.every((id) => evidence.has(id))) {
+      throw new Error(`Unapproved evidence in ${item.slug}`);
+    }
+
+    const nodeIds = new Set<string>();
+    for (const node of item.architecture.nodes) {
+      if (!/^[a-z0-9]+(?:-[a-z0-9]+)*$/.test(node.id) || nodeIds.has(node.id)) {
+        throw new Error(`Invalid or duplicate architecture node "${node.id}" in ${item.slug}`);
+      }
+      nodeIds.add(node.id);
+    }
+    if (nodeIds.size < 3) throw new Error(`Incomplete architecture in ${item.slug}`);
+    for (const edge of item.architecture.edges) {
+      if (!nodeIds.has(edge.source) || !nodeIds.has(edge.target)) {
+        throw new Error(`Dangling architecture edge "${edge.source}" → "${edge.target}" in ${item.slug}`);
+      }
+    }
+
+    const publicCopy = JSON.stringify(item);
+    if (stalePublicCopy.test(publicCopy)) {
+      throw new Error(`Stale incomplete-work copy in ${item.slug}`);
+    }
   }
+
   return items;
 }
 

--- a/tests/e2e/a11y-infrastructure.spec.ts
+++ b/tests/e2e/a11y-infrastructure.spec.ts
@@ -1,7 +1,7 @@
 import { expect, test } from '@playwright/test';
 import AxeBuilder from '@axe-core/playwright';
 
-for (const route of ['/', '/work', '/work/jobs-tracker-bot', '/experience', '/writing', '/writing/web-accessibility-2025', '/accessibility-checker']) {
+for (const route of ['/', '/work', '/work/ai-assisted-contract-workflow', '/work/jobs-tracker-bot', '/work/tactical-tech-platform-modernisation', '/work/web-crawler-dashboard', '/experience', '/writing', '/writing/web-accessibility-2025', '/accessibility-checker']) {
 test(`${route} has no automated axe violations @a11y`, async ({ page }, testInfo) => {
   await page.goto(route);
   const results = await new AxeBuilder({ page }).analyze();

--- a/tests/e2e/no-javascript.spec.ts
+++ b/tests/e2e/no-javascript.spec.ts
@@ -8,6 +8,11 @@ test('primary content remains understandable without JavaScript', async ({ brows
   await expect(page.getByRole('heading', { level: 1 })).toHaveText('Senior full-stack engineer');
   await expect(page.getByText('Product problem → Interface → API boundary → Service → Data/AI → Production')).toBeVisible();
 
+  await page.goto('/work/jobs-tracker-bot');
+  await expect(page.getByRole('heading', { level: 1 })).toHaveText('Jobs Tracker Bot');
+  await expect(page.getByText('Read the architecture as text')).toBeVisible();
+  await expect(page.getByRole('listitem').filter({ hasText: 'ATS adapters' })).toBeVisible();
+
   await page.goto('/writing/web-accessibility-2025');
   await expect(page.getByRole('heading', { level: 1 })).toContainText('A practical accessibility baseline');
   await expect(page.getByRole('heading', { level: 2, name: 'Test in layers' })).toBeVisible();

--- a/tests/e2e/work.spec.ts
+++ b/tests/e2e/work.spec.ts
@@ -11,8 +11,39 @@ test('redacted case study retains labels and text alternative', async ({ page },
   await page.setViewportSize({ width: 390, height: 844 });
   await page.goto('/work/ai-assisted-contract-workflow');
   await expect(page.getByText('Private / redacted case study')).toBeVisible();
-  await expect(page.getByText(/Structured user input then React editor/)).toBeAttached();
+  await expect(page.getByRole('complementary', { name: 'Evidence boundary' })).toBeVisible();
+  await expect(page.getByText('Read the architecture as text')).toBeVisible();
+  await expect(page.getByRole('listitem').filter({ hasText: 'Structured input' })).toBeAttached();
+  await expect(page.getByRole('heading', { name: 'Testing and delivery' })).toHaveCount(0);
+  await expect(page.getByRole('heading', { name: 'Next improvements' })).toHaveCount(0);
   await page.screenshot({ path: testInfo.outputPath('case-study-mobile.png'), fullPage: true });
+});
+
+test('Jobs Tracker dossier exposes outcomes, repository evidence, navigation, and architecture controls', async ({ page }, testInfo) => {
+  await page.goto('/work/jobs-tracker-bot');
+
+  await expect(page.getByRole('heading', { level: 1 })).toHaveText('Jobs Tracker Bot');
+  await expect(page.getByText('520+', { exact: true })).toBeVisible();
+  await expect(page.getByText('GitHub Actions → Oracle Cloud', { exact: true })).toBeVisible();
+  await expect(page.getByRole('link', { name: /View public repository/i })).toHaveAttribute('href', 'https://github.com/saqibroy/jobs-tracker-bot');
+  await expect(page.getByRole('navigation', { name: 'Case study sections' }).getByRole('link')).toHaveCount(7);
+
+  await page.getByText('Interactive system map').scrollIntoViewIfNeeded();
+  await expect(page.getByRole('group', { name: 'Jobs Tracker Bot interactive architecture map' })).toBeVisible();
+  await expect(page.getByText('Eligibility score', { exact: true }).first()).toBeVisible();
+  await expect(page.locator('.react-flow__controls-fitview')).toBeVisible();
+  const eligibilityNode = page.locator('.react-flow__node[data-id="eligibility"]');
+  await eligibilityNode.focus();
+  await page.keyboard.press('Enter');
+  await expect(page.locator('.architecture-selection').getByRole('heading')).toHaveText('Eligibility score');
+  await expect(page.getByText('Outcomes at a glance')).toHaveCount(0);
+  await expect(page.getByText(/under review|follow later|not publicly documented/i)).toHaveCount(0);
+  await page.evaluate(() => {
+    document.documentElement.style.scrollBehavior = 'auto';
+    window.scrollTo(0, 0);
+  });
+  await expect(page.locator('.dossier-breadcrumb')).toBeInViewport();
+  await page.screenshot({ path: testInfo.outputPath('jobs-dossier-desktop.png'), fullPage: true });
 });
 
 test('gated and missing case studies are not published', async ({ page }) => {

--- a/tests/portfolio-content.test.ts
+++ b/tests/portfolio-content.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'vitest';
 
 import { portfolioContent } from '@/content/portfolio';
-import { caseStudies, caseStudySectionKeys, validateCaseStudies } from '@/content/caseStudies';
+import { caseStudies, requiredCaseStudySectionKeys, validateCaseStudies } from '@/content/caseStudies';
 
 describe('portfolio content', () => {
   it('keeps the prominent title distinct from descriptive positioning', () => {
@@ -52,10 +52,27 @@ describe('portfolio content', () => {
 });
 
 describe('case studies', () => {
-  it('validates unique slugs, approved evidence, and every narrative key', () => {
+  it('validates unique slugs, approved evidence, and required narrative sections', () => {
     expect(() => validateCaseStudies(caseStudies)).not.toThrow();
     expect(new Set(caseStudies.map(({ slug }) => slug)).size).toBe(caseStudies.length);
-    for (const item of caseStudies) expect(caseStudySectionKeys.every((key) => key in item.sections)).toBe(true);
+    for (const item of caseStudies) {
+      expect(requiredCaseStudySectionKeys.every((key) => Boolean(item.sections[key]))).toBe(true);
+    }
+  });
+
+  it('rejects dangling architecture edges', () => {
+    const fixture = structuredClone(caseStudies);
+    fixture[0].architecture.edges.push({ source: fixture[0].architecture.nodes[0].id, target: 'missing-node' });
+
+    expect(() => validateCaseStudies(fixture)).toThrow(/Dangling architecture edge/);
+  });
+
+  it('omits unsupported optional sections instead of publishing disclaimers', () => {
+    const privateCase = caseStudies.find(({ slug }) => slug === 'ai-assisted-contract-workflow');
+
+    expect(privateCase?.sections.testingDelivery).toBeUndefined();
+    expect(privateCase?.sections.nextImprovements).toBeUndefined();
+    expect(JSON.stringify(caseStudies)).not.toMatch(/under review|follow later|return later|not publicly documented|details? (?:are|is) (?:omitted|unavailable)/i);
   });
 
   it('does not publish the gated accessibility platform', () => {


### PR DESCRIPTION
## What changed

- add typed structured outcomes, architecture nodes, and architecture edges with build-time validation
- reject dangling edges, missing core narrative sections, empty future-work sections, and stale incomplete-work wording
- replace every case-study page with the shared engineering-dossier layout
- add full-width outcomes, responsive sticky navigation, grouped narrative chapters, decision/trade-off cards, and private evidence boundaries
- add a deferred React Flow architecture map with keyboard selection, fit controls, and a complete ordered-text/no-JavaScript equivalent
- give Jobs Tracker Bot a purpose-built branching pipeline and direct GitHub repository evidence link
- remove the duplicated bottom outcomes block and unsupported empty sections

## Why

The previous case-study layout left a large empty rail, rendered fourteen identical paragraphs, and reduced architecture to a row of boxes. The new structure makes evidence, boundaries, decisions, and delivery legible without inventing unsupported detail.

## Validation

- `npm run lint`
- `npm run typecheck`
- `npm run test` (21 passed)
- `npm run test:e2e` (33 passed)
- `npm run test:a11y` (10 routes in both themes passed)
- `npm run build`
- `npm audit --omit=dev --audit-level=high` (0 production vulnerabilities)
- inspected Jobs Tracker desktop and private/redacted mobile captures

## Review note

This is a stacked draft based on PR #15. It must not merge until final preview screenshots and interactions are approved.
