### PR TITLE
Refine writing typography and URL shortener diagram

### DIFF
--- a/content/writing/designing-a-url-shortener.mdx
+++ b/content/writing/designing-a-url-shortener.mdx
@@ -27,7 +27,7 @@ I would start by confirming the smallest useful scope.
 - The system generates a unique short code.
 - Visiting the short URL redirects to the original URL.
 - The mapping remains available after a restart or deployment.
-- Duplicate short codes are never allowed.
+- Every short code resolves unambiguously to at most one active mapping.
 
 ### Questions that change the design
 
@@ -37,7 +37,7 @@ I would start by confirming the smallest useful scope.
 - Is authentication required?
 - Do we need click analytics?
 - What traffic should the system support?
-- Are links private, public, or both?
+- Are links publicly accessible, unlisted, or protected by authentication?
 
 For an interview-sized first version, I would support creation and redirection, then describe custom aliases, expiry and analytics as extensions.
 
@@ -82,10 +82,10 @@ GET /aZ91kQ
 
 Possible responses:
 
-- `302 Found` with a `Location` header when destinations may change;
-- `301 Moved Permanently` when mappings are immutable and long-term caching is desirable;
-- `404 Not Found` when the code does not exist;
-- `410 Gone` when the link existed but has expired.
+- `302 Found` with a `Location` header when destinations may change
+- `301 Moved Permanently` when mappings are immutable and long-term caching is desirable
+- `404 Not Found` when the code does not exist
+- `410 Gone` when the link existed but has expired
 
 I would begin with `302` unless the product explicitly guarantees immutable destinations. It gives the system more control if links need to be corrected, disabled or moderated later.
 
@@ -102,11 +102,9 @@ CREATE TABLE links (
   expires_at TIMESTAMPTZ NULL,
   created_by BIGINT NULL
 );
-
-CREATE UNIQUE INDEX links_code_unique ON links (code);
 ```
 
-The most important constraint is the unique index on `code`. Application-level checks alone are not sufficient because two requests may generate the same candidate at the same time.
+The most important constraint is the uniqueness requirement on `code`. Application-level checks alone are not sufficient because two requests may generate the same candidate at the same time. In PostgreSQL, the `UNIQUE` constraint automatically creates the supporting unique index.
 
 The redirect query stays simple:
 
@@ -115,6 +113,8 @@ SELECT original_url, expires_at
 FROM links
 WHERE code = $1;
 ```
+
+The optional `created_by` field would only be populated if authenticated link ownership is part of the product scope.
 
 ## 5. Choose the short-code strategy deliberately
 
@@ -128,7 +128,7 @@ Base62 uses:
 - `A-Z`
 - `0-9`
 
-A six-character code provides a large namespace while remaining easy to type and share. The exact length should depend on expected volume and acceptable collision retries.
+A six-character code provides approximately 56.8 billion possible values, although the appropriate length should account for expected volume, collision probability and retry rates.
 
 Creation flow:
 
@@ -137,16 +137,17 @@ Creation flow:
 3. If the unique constraint fails, generate a new code and retry.
 4. Limit retries and return an internal error if the unlikely collision loop cannot complete.
 
-A database sequence encoded as Base62 is also practical, but sequential codes make enumeration easier. A hash of the original URL appears deterministic, but truncation still creates collisions and identical destinations do not always need identical short links.
+A database sequence encoded as Base62 is also practical, but sequential codes make enumeration easier. Hashing the original URL does not eliminate collisions once the hash is shortened, and it couples code generation to deduplication semantics that the product may not want.
 
 ## 6. Separate validation from fetching
 
 The service should validate that the submitted destination:
 
-- parses as a URL;
-- uses `http` or `https`;
-- stays within the maximum accepted length;
-- does not use unsupported schemes such as `javascript:` or `data:`.
+- parses as a URL
+- uses `http` or `https`
+- stays within the maximum accepted length
+- does not use unsupported schemes such as `javascript:` or `data:`
+- does not create an obvious self-referential redirect loop
 
 A basic URL shortener does not need to fetch the destination during creation. Avoiding that network call keeps the create path smaller and avoids introducing unnecessary server-side request risks.
 
@@ -164,9 +165,11 @@ A simple read-through flow:
 4. Cache the result with a suitable TTL.
 5. Return the redirect.
 
-The database remains the source of truth.
+The application controls the fallback to PostgreSQL. Redis does not query the database itself, and PostgreSQL remains the source of truth.
 
 I would not add Redis automatically for a small internal product. A unique index and a healthy PostgreSQL instance may already be enough. The cache becomes valuable when measurements show that redirect traffic or database load justifies another operational dependency.
+
+If destinations can be edited, disabled or expired, the corresponding cache entry must be invalidated or updated during the write operation. The cache TTL acts only as a fallback, not as the primary consistency mechanism.
 
 Negative caching can also help with repeated requests for unknown codes, but the TTL should be short so a newly created code does not remain incorrectly cached as missing.
 
@@ -177,16 +180,16 @@ Click analytics are useful, but recording them synchronously can slow every redi
 A better design is:
 
 1. Resolve the destination.
-2. Publish a lightweight click event.
+2. Publish a lightweight click event to a queue.
 3. Return the redirect.
 4. Process analytics separately.
 
 The event might contain:
 
-- short code;
-- timestamp;
-- coarse referrer information;
-- privacy-safe location or device categories when permitted.
+- short code
+- timestamp
+- coarse referrer information
+- privacy-safe location or device categories when permitted
 
 The redirect should still succeed when the analytics consumer is delayed. Analytics are valuable, but they are not more important than the redirect itself.
 
@@ -196,32 +199,30 @@ The first production review should cover:
 
 ### Reliability
 
-- database connection failures;
-- cache outages;
-- retry behaviour;
-- timeouts;
-- expired links;
-- safe deployment and migration strategy;
-- health checks and monitoring.
+- timeout and fallback behaviour for database or cache failures
+- retry behaviour for non-user-facing background work
+- expired and disabled links
+- backward-compatible database migrations
+- health checks, redirect latency metrics and error-rate monitoring
 
 ### Abuse controls
 
-- rate limiting on link creation;
-- maximum URL length;
-- reserved custom aliases;
-- disabling malicious links;
-- reporting and moderation workflow;
-- protection against automated enumeration;
-- logs that avoid unnecessary personal data.
+- rate limiting on link creation
+- maximum URL length
+- reserved custom aliases
+- disabling malicious links
+- reporting and moderation workflow
+- protection against automated enumeration
+- logs that avoid unnecessary personal data
 
 ### Security
 
-- validate schemes;
-- encode output correctly;
-- avoid open administration endpoints;
-- protect authenticated link-management routes;
-- keep secrets outside the repository;
-- apply least-privilege database access.
+- validate schemes
+- encode output correctly
+- avoid open administration endpoints
+- protect authenticated link-management routes
+- keep secrets outside the repository
+- apply least-privilege database access
 
 ## 10. Scale in measured steps
 
@@ -229,32 +230,32 @@ I would explain scaling as a sequence rather than designing the largest possible
 
 ### Stage 1 — Simple application
 
-- one application service;
-- PostgreSQL;
-- indexed code lookup;
-- basic monitoring.
+- one application service
+- PostgreSQL
+- indexed code lookup
+- basic monitoring
 
 ### Stage 2 — Read optimisation
 
-- Redis read-through cache;
-- connection pooling;
-- separate create and redirect metrics;
-- rate limiting.
+- Redis read-through cache
+- connection pooling
+- separate create and redirect metrics
+- rate limiting
 
 ### Stage 3 — Higher traffic
 
-- multiple stateless service instances;
-- load balancer;
-- asynchronous analytics queue;
-- cache replication or managed cache;
-- database read strategy based on measured load.
+- multiple stateless service instances
+- load balancer
+- asynchronous analytics queue
+- cache replication or managed cache
+- database read strategy based on measured load
 
 ### Stage 4 — Global redirect traffic
 
-- regional or edge caching;
-- careful cache invalidation;
-- globally unique code generation;
-- operational tooling for abuse and link takedowns.
+- regional or edge caching
+- careful cache invalidation
+- globally unique code generation
+- operational tooling for abuse and link takedowns
 
 The important interview point is not to predict every future component. It is to show which measurement or product requirement would justify each one.
 
@@ -262,13 +263,13 @@ The important interview point is not to predict every future component. It is to
 
 My first-version decision would be:
 
-- PostgreSQL as the source of truth;
-- random Base62 codes;
-- a database unique constraint with collision retry;
-- `302` redirects while destinations remain changeable;
-- no cache until traffic justifies it;
-- asynchronous analytics;
-- explicit validation and creation rate limits.
+- PostgreSQL as the source of truth
+- random Base62 codes
+- a database unique constraint with collision retry
+- `302` redirects while destinations remain changeable
+- no cache until traffic justifies it
+- asynchronous analytics through a queue
+- explicit validation and creation rate limits
 
 This is intentionally simple. It gives the product a correct and maintainable base while leaving clear extension points for caching, analytics, expiry, custom aliases and global delivery.
 
@@ -279,12 +280,13 @@ I would use this order:
 1. Restate the goal.
 2. Confirm functional requirements.
 3. Ask about traffic, mutability, expiry and analytics.
-4. Draw create and redirect paths separately.
-5. Define the API and data model.
-6. Choose a code-generation strategy.
-7. Explain correctness through the unique constraint.
-8. Discuss caching only after the basic design.
-9. Cover failure, abuse and security.
-10. End with trade-offs and the next scaling step.
+4. Write confirmed answers under headings such as users, requirements, constraints and scale.
+5. Draw create and redirect paths separately.
+6. Define the API and data model.
+7. Choose a code-generation strategy.
+8. Explain correctness through the unique constraint.
+9. Discuss caching only after the basic design.
+10. Cover failure, abuse and security.
+11. End with trade-offs and the next scaling step.
 
 That structure matters as much as the final diagram. It helps the interviewer follow the reasoning and makes it easier to recover when a requirement changes.

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -408,7 +408,8 @@ a { color: inherit; }
 .writing-hero h1, .writing-post h1 { max-width: 18ch; margin: 0; font-size: clamp(2.5rem, 5vw, 4.5rem); line-height: 1.02; letter-spacing: -.04em; }
 .writing-hero > p:last-child, .writing-post header > p:not(.writing-meta) { max-width: 44rem; color: var(--text-muted); font-size: 1.18rem; line-height: 1.65; }
 .writing-list { border-top: 1px solid var(--border); }
-.writing-list > article { padding: clamp(2rem, 5vw, 3.5rem) 0; border-bottom: 1px solid var(--border); }
+.writing-list > article { display: grid; grid-template-columns: minmax(8rem, .4fr) minmax(0, 1fr); gap: .25rem clamp(1.5rem, 6vw, 5rem); padding: clamp(2rem, 5vw, 3.5rem) 0; border-bottom: 1px solid var(--border); }
+.writing-list .writing-meta { grid-row: span 3; padding-top: .45rem; }
 .writing-list h2 { max-width: 28ch; margin: .4rem 0 .8rem; font-size: clamp(1.7rem, 3vw, 2.45rem); line-height: 1.08; }
 .writing-list h2 a, .writing-post nav a, .writing-content a { color: var(--accent-strong); }
 .writing-list > article > p:not(.writing-meta) { max-width: 44rem; color: var(--text-muted); font-size: 1.05rem; line-height: 1.6; }
@@ -419,15 +420,38 @@ a { color: inherit; }
 .writing-post > nav { margin-bottom: 2.5rem; color: var(--text-muted); font-size: .9rem; }
 .writing-post > header { max-width: 56rem; padding-bottom: 3rem; border-bottom: 1px solid var(--border); }
 .writing-post header h1 { margin: .7rem 0 1.25rem; }
-.writing-content { max-width: 46rem; padding-top: 3rem; font-size: 1.08rem; line-height: 1.72; }
-.writing-content h2 { margin: 3rem 0 1rem; font-size: clamp(1.65rem, 3vw, 2.35rem); line-height: 1.1; }
-.writing-content p, .writing-content li { color: var(--text-muted); }
-.writing-content ul, .writing-content ol { padding-left: 1.35rem; }
-.writing-content li { margin: .55rem 0; }
-.writing-content code { padding: .1rem .3rem; border-radius: .25rem; background: var(--surface-muted); font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace; font-size: .9em; }
-.writing-content pre { overflow-x: auto; padding: 1rem; border-radius: .5rem; background: var(--surface-muted); }
-.writing-content pre code { padding: 0; background: transparent; }
-@media (max-width: 700px) { .writing-page, .writing-post { width: min(100% - 1.25rem, 72rem); } }
+.writing-content { max-width: 46rem; padding-top: clamp(2.5rem, 6vw, 4rem); font-size: clamp(1.03rem, 1vw + .8rem, 1.12rem); line-height: 1.78; }
+.writing-content > :first-child { margin-top: 0; }
+.writing-content h2, .writing-content h3, .writing-content h4 { color: var(--text); letter-spacing: -.035em; text-wrap: balance; }
+.writing-content h2 { max-width: 22ch; margin: clamp(3.5rem, 8vw, 5rem) 0 1.15rem; font-size: clamp(1.75rem, 3vw, 2.55rem); line-height: 1.05; }
+.writing-content h3 { margin: 2.1rem 0 .7rem; font-family: var(--font-source-sans), Arial, sans-serif; font-size: 1.24rem; line-height: 1.25; }
+.writing-content h4 { margin: 1.7rem 0 .5rem; font-family: var(--font-source-sans), Arial, sans-serif; font-size: 1.05rem; line-height: 1.35; }
+.writing-content p { max-width: 65ch; margin: 1.15rem 0; color: var(--text-muted); }
+.writing-content strong { color: var(--text); font-weight: 750; }
+.writing-content a { font-weight: 700; text-decoration-line: underline; text-decoration-thickness: .08em; text-underline-offset: .18em; }
+.writing-content a:hover { color: var(--text); text-decoration-color: var(--accent); }
+.writing-content ul, .writing-content ol { max-width: 62ch; margin: 1.35rem 0 1.6rem; padding: 0; color: var(--text-muted); list-style: none; }
+.writing-content li { position: relative; margin: .7rem 0; padding-left: 1.4rem; }
+.writing-content ul > li::before { position: absolute; top: .73em; left: .15rem; width: .38rem; height: .38rem; border-radius: 50%; background: var(--accent); content: ''; }
+.writing-content ol { counter-reset: article-list; }
+.writing-content ol > li { counter-increment: article-list; }
+.writing-content ol > li::before { position: absolute; left: 0; color: var(--accent-strong); content: counter(article-list) '.'; font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace; font-size: .78em; font-weight: 750; }
+.writing-content li > ul, .writing-content li > ol { margin: .55rem 0 .3rem; }
+.writing-content li > ul > li::before { width: .33rem; height: .33rem; border: 1px solid var(--accent); background: transparent; }
+.writing-content code { padding: .12rem .34rem; border: 1px solid color-mix(in srgb, var(--border) 80%, transparent); border-radius: .25rem; background: var(--surface-muted); color: var(--text); font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace; font-size: .86em; }
+.writing-content pre { overflow-x: auto; margin: 1.8rem 0; padding: clamp(1rem, 3vw, 1.4rem); border: 1px solid var(--border); border-left: 3px solid var(--accent); border-radius: .35rem; background: var(--surface-muted); color: var(--text); font-size: .88rem; line-height: 1.65; }
+.writing-content pre code { padding: 0; border: 0; background: transparent; color: inherit; font-size: inherit; }
+.writing-content blockquote { max-width: 60ch; margin: 1.8rem 0; padding: .2rem 0 .2rem 1.25rem; border-left: 3px solid var(--accent); color: var(--text); font-family: var(--font-source-serif), Georgia, serif; font-size: 1.18rem; line-height: 1.5; }
+.writing-content blockquote > :first-child { margin-top: 0; }.writing-content blockquote > :last-child { margin-bottom: 0; }
+.writing-content hr { height: 1px; margin: 3rem 0; border: 0; background: var(--border); }
+.writing-content-table { max-width: 100%; overflow-x: auto; margin: 2rem 0; border: 1px solid var(--border); }
+.writing-content-table table { width: 100%; min-width: 34rem; border-collapse: collapse; }
+.writing-content-table th, .writing-content-table td { padding: .85rem 1rem; border-top: 1px solid var(--border); color: var(--text-muted); text-align: left; vertical-align: top; line-height: 1.55; }
+.writing-content-table th { color: var(--text); font-family: var(--font-source-sans), Arial, sans-serif; font-weight: 750; }
+.writing-content-table thead { background: color-mix(in srgb, var(--accent) 6%, var(--surface)); }
+.writing-content details { margin: 1.5rem 0; padding: .85rem 1rem; border: 1px solid var(--border); background: var(--surface-muted); }
+.writing-content summary { cursor: pointer; color: var(--accent-strong); font-weight: 750; }
+@media (max-width: 700px) { .writing-page, .writing-post { width: min(100% - 1.25rem, 72rem); } .writing-list > article { display: block; } .writing-list .writing-meta { padding-top: 0; } .writing-content { font-size: 1rem; line-height: 1.72; } .writing-content h2 { margin-top: 3.25rem; } .writing-content pre { margin-inline: -.1rem; } }
 
 .checker-page { width: min(100% - 2rem, 62rem); margin: 0 auto; padding: clamp(4rem, 8vw, 7rem) 0; }
 .checker-hero { max-width: 52rem; padding-bottom: 3rem; border-bottom: 1px solid var(--border); }

--- a/src/components/writing/ArticleContent.tsx
+++ b/src/components/writing/ArticleContent.tsx
@@ -7,6 +7,7 @@ import { UrlShortenerArchitecture } from './UrlShortenerArchitecture';
 const components = {
   pre: (props: ComponentProps<'pre'>) => <pre {...props} />,
   code: (props: ComponentProps<'code'>) => <code {...props} />,
+  table: ({ children, ...props }: ComponentProps<'table'>) => <div className="writing-content-table"><table {...props}>{children}</table></div>,
   UrlShortenerArchitecture,
   ShortCodeTradeoffMatrix,
 };

--- a/src/components/writing/UrlShortenerArchitecture.tsx
+++ b/src/components/writing/UrlShortenerArchitecture.tsx
@@ -1,43 +1,200 @@
 const nodes = [
-  { label: 'Link creator', type: 'External actor', x: 20, y: 90 },
-  { label: 'Visitor', type: 'External actor', x: 20, y: 265 },
-  { label: 'Next.js application', type: 'UI + API + redirects', x: 235, y: 175 },
-  { label: 'PostgreSQL', type: 'Data store', x: 475, y: 90 },
-  { label: 'Cache', type: 'Cache', x: 475, y: 265 },
-  { label: 'Analytics worker', type: 'Async component', x: 650, y: 265 },
-] as const;
+  { label: 'Link creator', type: 'External actor', x: 20, y: 70 },
+  { label: 'Visitor', type: 'External actor', x: 20, y: 270 },
+  {
+    label: 'Next.js application',
+    type: 'UI + API + redirects',
+    x: 220,
+    y: 170,
+  },
+  { label: 'PostgreSQL', type: 'Source of truth', x: 455, y: 70 },
+  { label: 'Redis cache', type: 'Optional cache', x: 455, y: 270 },
+  { label: 'Event queue', type: 'Async buffer', x: 635, y: 205 },
+  { label: 'Analytics worker', type: 'Async processor', x: 635, y: 305 },
+] as const
 
-const nodeWidth = 145;
-const nodeHeight = 64;
+const nodeWidth = 145
+const nodeHeight = 64
 
-function arrow(sourceX: number, sourceY: number, targetX: number, targetY: number) {
-  return `M ${sourceX} ${sourceY} L ${targetX} ${targetY}`;
+function arrow(
+  sourceX: number,
+  sourceY: number,
+  targetX: number,
+  targetY: number,
+) {
+  return `M ${sourceX} ${sourceY} L ${targetX} ${targetY}`
 }
 
 export function UrlShortenerArchitecture() {
-  return <figure className="url-shortener-architecture">
-    <figcaption>One Next.js application: creation UI, API route handlers, and redirects</figcaption>
-    <svg viewBox="0 0 820 405" aria-hidden="true">
-      <defs><marker id="url-arrow" markerWidth="8" markerHeight="8" refX="7" refY="4" orient="auto"><path d="M0,0 L8,4 L0,8 Z" /></marker></defs>
-      <g className="url-system-boundary"><rect x="205" y="40" width="595" height="335" rx="8" /><text x="221" y="65">URL shortener</text></g>
-      <g className="url-architecture-relationships">
-        <path d={arrow(165, 122, 235, 207)} markerEnd="url(#url-arrow)" />
-        <path d={arrow(165, 297, 235, 239)} markerEnd="url(#url-arrow)" />
-        <path d={arrow(380, 207, 475, 122)} markerEnd="url(#url-arrow)" />
-        <path d={arrow(380, 239, 475, 297)} markerEnd="url(#url-arrow)" />
-        <path d={arrow(547, 265, 547, 154)} markerEnd="url(#url-arrow)" />
-        <path className="url-async-path" d={arrow(380, 239, 650, 297)} markerEnd="url(#url-arrow)" />
-      </g>
-      {nodes.map((node) => <g key={node.label} className={`url-architecture-node url-architecture-node--${node.type.toLowerCase().replaceAll(' ', '-').replaceAll(':', '')}`}><rect x={node.x} y={node.y} width={nodeWidth} height={nodeHeight} rx="7" /><text x={node.x + nodeWidth / 2} y={node.y + 27} textAnchor="middle">{node.label}</text><text className="url-architecture-node-type" x={node.x + nodeWidth / 2} y={node.y + 48} textAnchor="middle">{node.type}</text></g>)}
-      <g className="url-architecture-labels">
-        <text x="190" y="158" textAnchor="middle">submits original URL</text>
-        <text x="190" y="276" textAnchor="middle">visits short URL</text>
-        <text x="425" y="151" textAnchor="middle">creates mapping</text>
-        <text x="425" y="282" textAnchor="middle">resolves code</text>
-        <text x="572" y="211" textAnchor="middle">cache miss</text>
-        <text x="520" y="355" textAnchor="middle">event; not on redirect response</text>
-      </g>
-    </svg>
-    <details className="url-shortener-text-equivalent"><summary>Read the architecture as text</summary><ul><li><strong>Single application:</strong> one Next.js deployment contains the creation UI, the <code>POST /api/links</code> handler, and the short-link redirect route.</li><li><strong>Create:</strong> a link creator submits an original URL. The Next.js handler validates it, generates a code, and stores the mapping in PostgreSQL.</li><li><strong>Redirect:</strong> a visitor reaches the Next.js redirect route, which checks the cache before PostgreSQL on a miss.</li><li><strong>Analytics:</strong> the redirect route emits an event to an asynchronous worker; it does not delay the redirect response.</li></ul></details>
-  </figure>;
+  return (
+    <figure className="url-shortener-architecture">
+      <figcaption>
+        One Next.js application with separate create, redirect and analytics flows
+      </figcaption>
+
+      <svg
+        viewBox="0 0 820 420"
+        role="img"
+        aria-labelledby="url-architecture-title url-architecture-description"
+      >
+        <title id="url-architecture-title">URL shortener architecture</title>
+        <desc id="url-architecture-description">
+          A link creator submits a long URL to a Next.js application, which validates
+          it and stores the mapping in PostgreSQL. A visitor opens a short URL, and
+          the application checks Redis before falling back to PostgreSQL. Click
+          events are published to a queue and processed asynchronously.
+        </desc>
+
+        <defs>
+          <marker
+            id="url-arrow"
+            markerWidth="8"
+            markerHeight="8"
+            refX="7"
+            refY="4"
+            orient="auto"
+          >
+            <path d="M0,0 L8,4 L0,8 Z" />
+          </marker>
+        </defs>
+
+        <g className="url-system-boundary">
+          <rect x="195" y="35" width="605" height="350" rx="8" />
+          <text x="212" y="60">
+            URL shortener
+          </text>
+        </g>
+
+        <g className="url-architecture-relationships">
+          <path
+            d={arrow(165, 102, 220, 198)}
+            markerEnd="url(#url-arrow)"
+          />
+          <path
+            d={arrow(165, 302, 220, 232)}
+            markerEnd="url(#url-arrow)"
+          />
+
+          <path
+            d={arrow(365, 198, 455, 102)}
+            markerEnd="url(#url-arrow)"
+          />
+
+          <path
+            d={arrow(365, 232, 455, 302)}
+            markerEnd="url(#url-arrow)"
+          />
+          <path
+            className="url-cache-miss-path"
+            d={arrow(365, 214, 455, 134)}
+            markerEnd="url(#url-arrow)"
+          />
+          <path
+            className="url-cache-fill-path"
+            d={arrow(455, 150, 365, 246)}
+            markerEnd="url(#url-arrow)"
+          />
+
+          <path
+            className="url-async-path"
+            d={arrow(365, 246, 635, 237)}
+            markerEnd="url(#url-arrow)"
+          />
+          <path
+            className="url-async-path"
+            d={arrow(707, 269, 707, 305)}
+            markerEnd="url(#url-arrow)"
+          />
+        </g>
+
+        {nodes.map((node) => (
+          <g
+            key={node.label}
+            className={`url-architecture-node url-architecture-node--${node.type
+              .toLowerCase()
+              .replaceAll(' ', '-')
+              .replaceAll(':', '')}`}
+          >
+            <rect
+              x={node.x}
+              y={node.y}
+              width={nodeWidth}
+              height={nodeHeight}
+              rx="7"
+            />
+            <text
+              x={node.x + nodeWidth / 2}
+              y={node.y + 27}
+              textAnchor="middle"
+            >
+              {node.label}
+            </text>
+            <text
+              className="url-architecture-node-type"
+              x={node.x + nodeWidth / 2}
+              y={node.y + 48}
+              textAnchor="middle"
+            >
+              {node.type}
+            </text>
+          </g>
+        ))}
+
+        <g className="url-architecture-labels">
+          <text x="184" y="145" textAnchor="middle">
+            submits original URL
+          </text>
+          <text x="185" y="285" textAnchor="middle">
+            visits short URL
+          </text>
+
+          <text x="420" y="145" textAnchor="middle">
+            creates mapping
+          </text>
+          <text x="412" y="282" textAnchor="middle">
+            1. cache lookup
+          </text>
+          <text x="424" y="184" textAnchor="middle">
+            2. DB fallback
+          </text>
+          <text x="420" y="255" textAnchor="middle">
+            3. populate cache
+          </text>
+
+          <text x="505" y="225" textAnchor="middle">
+            click event
+          </text>
+          <text x="746" y="292" textAnchor="middle">
+            consume
+          </text>
+        </g>
+      </svg>
+
+      <details className="url-shortener-text-equivalent">
+        <summary>Read the architecture as text</summary>
+        <ul>
+          <li>
+            <strong>Single application:</strong> one Next.js deployment contains
+            the creation UI, the <code>POST /api/links</code> handler and the
+            short-link redirect route.
+          </li>
+          <li>
+            <strong>Create:</strong> a link creator submits an original URL. The
+            Next.js handler validates it, generates a code and stores the mapping
+            in PostgreSQL.
+          </li>
+          <li>
+            <strong>Redirect:</strong> a visitor reaches the Next.js redirect
+            route. The application checks Redis first and queries PostgreSQL on a
+            cache miss, then populates the cache.
+          </li>
+          <li>
+            <strong>Analytics:</strong> the redirect route publishes a click event
+            to a queue. A separate worker consumes it asynchronously, so analytics
+            processing does not delay the redirect response.
+          </li>
+        </ul>
+      </details>
+    </figure>
+  )
 }

--- a/tests/e2e/writing.spec.ts
+++ b/tests/e2e/writing.spec.ts
@@ -28,8 +28,8 @@ test('writing index exposes only reviewed notes', async ({ page }, testInfo) => 
 
 test('URL-shortener article exposes its system-design visuals accessibly', async ({ page }) => {
   await page.goto('/writing/designing-a-url-shortener');
-  await expect(page.getByText('One Next.js application: creation UI, API route handlers, and redirects')).toBeVisible();
-  await expect(page.getByText('event; not on redirect response')).toBeVisible();
+  await expect(page.getByText('One Next.js application with separate create, redirect and analytics flows')).toBeVisible();
+  await expect(page.getByText('click event', { exact: true })).toBeVisible();
   await expect(page.getByRole('table', { name: 'Short-code strategy trade-offs' })).toBeVisible();
   await expect(page.getByRole('rowheader', { name: 'Random Base62' })).toBeVisible();
 });


### PR DESCRIPTION
## Summary

Improves the visual hierarchy and readability of every MDX writing page, using the URL-shortener article as the reference. It also updates that article’s system-design architecture to clarify one Next.js deployment, cache behaviour, and asynchronous analytics.

## What changed

- Adds a readable editorial layout to the writing index.
- Styles headings, body copy, lists, links, code blocks, blockquotes, tables, and details content across MDX articles.
- Makes standard Markdown tables responsive.
- Updates the URL-shortener article and architecture diagram with explicit create, redirect, Redis cache, queue, and worker paths.
- Updates writing E2E assertions for the revised accessible visual.

## Validation

- `npm run lint`
- `npm run typecheck`
- `npm run test`
- `npx playwright test tests/e2e/writing.spec.ts --project=chromium`
- `npm run build`