### PR TITLE
Add RAG reliability article and interactive diagrams

### DIFF
--- a/content/writing/rag-is-not-a-truth-machine.mdx
+++ b/content/writing/rag-is-not-a-truth-machine.mdx
@@ -1,0 +1,314 @@
+---
+title: "RAG Is Not a Truth Machine: Designing AI Assistants That Fail Safely"
+date: "2026-07-29"
+description: "A practical look at what retrieval-augmented generation can and cannot guarantee, using the Air Canada chatbot case to examine retrieval, evidence checks, evaluation and safe failure."
+author: "Saqib Sohail"
+tags:
+  - AI
+  - RAG
+  - System design
+  - LLMs
+  - Reliability
+reviewStatus: "publicly-verified"
+---
+
+A customer asks a chatbot a policy question. The answer is clear, confident and wrong.
+
+That is not only a model-quality problem. Once the assistant represents a company, its answer can affect money, trust and legal responsibility.
+
+The widely discussed Air Canada chatbot case is a useful example. A passenger asked about bereavement fares and was told that the discount could be requested after travel. Air Canada later rejected the request because its actual policy did not allow that. In *Moffatt v. Air Canada*, the British Columbia Civil Resolution Tribunal held the airline responsible for the inaccurate information and awarded damages, interest and tribunal fees.
+
+The engineering lesson is broader than one chatbot:
+
+> A fluent answer is not the same as a verified answer, and adding retrieval does not make that distinction disappear.
+
+This article was inspired by Netguru's webinar on retrieval-augmented generation. The architecture and conclusions below are my own analysis, supported by the sources listed at the end.
+
+## 1. What RAG changes
+
+A language model generates an answer from the information available in its context and from patterns encoded in its parameters. It does not automatically know which internal policy is current, which source is authoritative or whether two documents contradict each other.
+
+Retrieval-augmented generation, usually shortened to RAG, adds an external knowledge step:
+
+1. The user asks a question.
+2. The system searches an approved knowledge base.
+3. Relevant passages are added to the model context.
+4. The model generates an answer using those passages.
+
+The original RAG research described this as combining a model's parametric memory with an external, non-parametric memory. In practical product terms, it means that company documents can be updated without retraining the model, and answers can be linked back to source material.
+
+<RagArchitecture />
+
+This is a meaningful improvement over asking a general model to answer a company-specific question from memory. It gives the model evidence that is current, private and domain-specific.
+
+It does not prove that the final answer is correct.
+
+## 2. The ingestion pipeline is part of the product
+
+A RAG request starts long before the user sends a message.
+
+Documents first need to be collected, parsed, cleaned, divided into useful chunks and enriched with metadata. Embeddings may then represent those chunks as vectors so the system can retrieve semantically related content.
+
+A basic ingestion pipeline might look like this:
+
+```text
+Source systems
+  → extract documents
+  → parse and clean content
+  → split into chunks
+  → attach metadata
+  → create embeddings
+  → store text and vectors
+```
+
+Useful metadata can include:
+
+- source URL or document identifier;
+- title and section;
+- page number;
+- product, country or customer segment;
+- publication and effective dates;
+- document version;
+- owner and approval status;
+- access-control information.
+
+This data is not decorative. It determines whether the retrieval layer can distinguish a current German refund policy from an expired Canadian policy, or an approved document from an internal draft.
+
+Poor ingestion creates errors that no prompt can reliably repair later.
+
+## 3. Retrieval is a ranking problem, not a lookup guarantee
+
+Vector similarity is useful because users rarely phrase questions exactly like the source material. However, semantic similarity does not necessarily mean that a passage answers the question.
+
+A query about whether a refund is available may retrieve:
+
+- a general refund overview;
+- an expired exception;
+- a document for another market;
+- a policy that mentions similar terminology but applies to a different fare;
+- a support article that omits an important condition.
+
+A production system therefore needs more than "take the nearest ten vectors."
+
+Possible improvements include:
+
+- hybrid keyword and vector search;
+- metadata filtering before retrieval;
+- query rewriting for ambiguous questions;
+- multiple retrieval queries;
+- reranking the candidate passages;
+- diversity controls to avoid ten near-duplicate chunks;
+- permission filtering;
+- an evidence-sufficiency check before generation.
+
+Agent-assisted retrieval, discussed in the webinar, can generate several searches instead of relying on the user's wording alone. That may improve recall, but it also adds latency, cost and another probabilistic component. I would introduce it only when evaluation shows that simpler retrieval misses important evidence.
+
+## 4. Where RAG still fails
+
+<RagFailureModes />
+
+A RAG system can fail at several independent layers.
+
+### Ingestion failure
+
+The source may be missing, badly parsed or split at the wrong boundaries. A table may lose its headings. A PDF footnote may become detached from the rule it qualifies.
+
+### Source-governance failure
+
+The knowledge base may contain outdated, duplicated or contradictory policies. Retrieval can faithfully return the wrong version.
+
+### Retrieval failure
+
+The correct source exists but is not returned, or a superficially similar passage receives a higher score.
+
+### Context failure
+
+The correct evidence is retrieved but truncated, mixed with conflicting evidence or placed in a context that is too large and noisy.
+
+### Generation failure
+
+The model may overgeneralise, combine separate rules or add an unsupported detail while producing a fluent answer.
+
+### Citation failure
+
+A response may display a real source even though the source does not support every claim in the answer. A citation is useful only when the claim-to-source relationship is checked.
+
+This is why I would avoid saying that RAG "stops hallucinations." It can substantially reduce unsupported answers, especially for domain-specific knowledge, but the system still needs controls around retrieval, generation and source quality.
+
+## 5. Refusal is a product feature
+
+One of the most important behaviours in a trustworthy assistant is the ability to say:
+
+> I do not have enough approved information to answer that.
+
+A similarity threshold can help, but a fixed number such as `0.60` is not a universal truth boundary. Scores vary by embedding model, index, chunking strategy and query type. Thresholds should be calibrated against an evaluation dataset.
+
+For a policy assistant, I would separate answers into three paths:
+
+1. **Supported answer** — sufficient, consistent evidence is available.
+2. **Clarification required** — the question is missing a country, product, date or other condition.
+3. **Refuse or escalate** — evidence is missing, conflicting or too weak.
+
+High-impact topics such as eligibility, prices, refunds, medical guidance or legal rights should use stricter evidence rules than low-risk questions such as navigation or opening hours.
+
+The assistant should not hide uncertainty behind polished language.
+
+## 6. Design the answer contract
+
+A safe architecture constrains not only what the model receives, but also what it is allowed to return.
+
+For policy questions, the response contract could require:
+
+```json
+{
+  "status": "supported | clarification_required | insufficient_evidence",
+  "answer": "string",
+  "claims": [
+    {
+      "text": "string",
+      "sourceIds": ["policy-2026-04"],
+      "support": "direct | inferred"
+    }
+  ],
+  "effectiveDate": "2026-04-01",
+  "escalationRequired": false
+}
+```
+
+The application can then validate:
+
+- every material claim has a source;
+- each source is current and approved;
+- the answer does not cite inaccessible documents;
+- unsupported statuses do not contain definitive advice;
+- high-risk responses meet stricter rules;
+- the displayed link resolves to the cited source.
+
+Structured output does not eliminate model errors, but it gives the rest of the system something testable.
+
+## 7. Evaluate retrieval and generation separately
+
+A few successful manual conversations are not enough to evaluate a RAG product.
+
+The test dataset should represent real questions, including difficult cases:
+
+- direct questions with one clear answer;
+- paraphrased and misspelled questions;
+- questions requiring multiple passages;
+- questions with no answer in the knowledge base;
+- ambiguous questions requiring clarification;
+- outdated or conflicting sources;
+- attempts to override the assistant's policy;
+- high-risk questions that should escalate.
+
+I would measure at least two layers.
+
+### Retrieval quality
+
+- Did the system retrieve the required source?
+- At what rank did it appear?
+- Did irrelevant passages dominate the context?
+- Were permissions and metadata filters applied correctly?
+
+### Answer quality
+
+- Is the response supported by the retrieved context?
+- Is it relevant to the question?
+- Does it include all necessary conditions?
+- Are citations attached to the claims they support?
+- Did the system refuse when evidence was insufficient?
+
+Microsoft's RAG evaluation guidance, for example, treats retrieval, groundedness, relevance and completeness as separate concerns. NVIDIA's guidance similarly distinguishes groundedness from context recall. That separation matters because an excellent generator cannot recover evidence that retrieval never supplied.
+
+## 8. Build a production feedback loop
+
+<RagReliabilityLoop />
+
+Offline evaluation catches known cases. Production observability reveals cases the team did not anticipate.
+
+I would log enough information to reconstruct a failure:
+
+- original and rewritten queries;
+- retrieved document identifiers and scores;
+- versions and effective dates;
+- the context supplied to the model;
+- model and prompt versions;
+- structured response and citations;
+- latency, token usage and failure status;
+- user feedback or human-review outcome.
+
+Sensitive content should be minimised, redacted where necessary and retained according to a defined policy.
+
+The useful loop is:
+
+1. Detect a weak or disputed production answer.
+2. Reproduce it from the trace.
+3. Decide whether the problem came from data, retrieval, prompting or validation.
+4. Add the case to the evaluation dataset.
+5. Fix the narrowest responsible layer.
+6. Run the full regression suite.
+7. Deploy and continue monitoring.
+
+This turns observability into engineering feedback rather than a dashboard that nobody uses.
+
+## 9. A safer architecture for company policy
+
+My first production design would use:
+
+- approved, versioned policy documents as the source of truth;
+- ingestion with parsing checks and metadata validation;
+- hybrid retrieval with product, market and effective-date filters;
+- reranking before context assembly;
+- explicit evidence sufficiency and conflict detection;
+- structured generation with claim-level source identifiers;
+- post-generation validation;
+- refusal or human escalation for weak evidence;
+- offline regression tests and production tracing.
+
+I would not begin with a complex autonomous agent unless simpler retrieval failed measured use cases. The goal is not to maximise the number of AI components. The goal is to make the decision path understandable and testable.
+
+## 10. What the Air Canada case changes for engineers
+
+The case does not establish a universal technical standard for every chatbot. It does show why teams cannot treat a public assistant as an independent actor that owns its own mistakes.
+
+From an engineering perspective, that means:
+
+- product owners must define which questions the assistant may answer;
+- content owners must maintain authoritative sources;
+- engineers must design refusal and escalation paths;
+- QA must test unsupported and contradictory cases;
+- operations teams must be able to reconstruct disputed answers;
+- the organisation must remain accountable for the experience it deploys.
+
+A chatbot response is part of the product surface. Reliability cannot be delegated to the model.
+
+## 11. The practical conclusion
+
+RAG is valuable because it can connect generation to current, private and inspectable evidence. It can improve factuality, make updates easier and provide provenance.
+
+But RAG is not a truth machine.
+
+The reliability of the final product depends on the whole path:
+
+```text
+source quality
+  → ingestion quality
+  → retrieval quality
+  → context quality
+  → generation constraints
+  → validation
+  → evaluation
+  → production feedback
+```
+
+The strongest design is not the one that always produces an answer. It is the one that knows when an answer is supported, shows the evidence and fails safely when it is not.
+
+## Sources and further reading
+
+- [Netguru webinar: How RAG Stops Your AI From Making Things Up](https://www.linkedin.com/posts/netguru_air-canadas-chatbot-promised-a-passenger-activity-7482382071508819969-fmhs)
+- [Moffatt v. Air Canada, 2024 BCCRT 149 (CanLII)](https://www.canlii.org/en/bc/bccrt/doc/2024/2024bccrt149/2024bccrt149.html)
+- [Retrieval-Augmented Generation for Knowledge-Intensive NLP Tasks](https://arxiv.org/abs/2005.11401)
+- [Retrieval-Augmented Generation for Large Language Models: A Survey](https://arxiv.org/abs/2312.10997)
+- [Microsoft Foundry: RAG evaluators](https://learn.microsoft.com/en-us/azure/ai-foundry/concepts/evaluation-evaluators/rag-evaluators)
+- [NVIDIA RAG Blueprint: evaluation guidance](https://docs.nvidia.com/rag/latest/evaluate.html)
+- [Netguru: Trusted AI chatbot for dental professionals](https://www.netguru.com/clients/trusted-ai-chatbot-for-dental-professionals)

--- a/content/writing/rag-is-not-a-truth-machine.mdx
+++ b/content/writing/rag-is-not-a-truth-machine.mdx
@@ -1,7 +1,7 @@
 ---
 title: "RAG Is Not a Truth Machine: Designing AI Assistants That Fail Safely"
 date: "2026-07-29"
-description: "A practical look at what retrieval-augmented generation can and cannot guarantee, using the Air Canada chatbot case to examine retrieval, evidence checks, evaluation and safe failure."
+description: "A practical look at what retrieval-augmented generation can and cannot solve, using the Air Canada chatbot case to explain grounding, safe refusal and production testing."
 author: "Saqib Sohail"
 tags:
   - AI
@@ -12,303 +12,337 @@ tags:
 reviewStatus: "publicly-verified"
 ---
 
-A customer asks a chatbot a policy question. The answer is clear, confident and wrong.
+A customer asks a company chatbot a policy question. The answer sounds clear and confident, so the customer trusts it.
 
-That is not only a model-quality problem. Once the assistant represents a company, its answer can affect money, trust and legal responsibility.
+Later, the company says the answer was wrong.
 
-The widely discussed Air Canada chatbot case is a useful example. A passenger asked about bereavement fares and was told that the discount could be requested after travel. Air Canada later rejected the request because its actual policy did not allow that. In *Moffatt v. Air Canada*, the British Columbia Civil Resolution Tribunal held the airline responsible for the inaccurate information and awarded damages, interest and tribunal fees.
+That is what made the Air Canada chatbot case so widely discussed. A passenger asked about bereavement fares and was told that he could request the discount after travelling. Air Canada later rejected the request because its real policy did not allow that.
 
-The engineering lesson is broader than one chatbot:
+In *Moffatt v. Air Canada*, the British Columbia Civil Resolution Tribunal held the airline responsible for the inaccurate information provided through its website and awarded the passenger damages, interest and tribunal fees.
 
-> A fluent answer is not the same as a verified answer, and adding retrieval does not make that distinction disappear.
+The important engineering lesson is simple:
 
-This article was inspired by Netguru's webinar on retrieval-augmented generation. The architecture and conclusions below are my own analysis, supported by the sources listed at the end.
+> A confident answer is not necessarily a verified answer.
 
-## 1. What RAG changes
+Retrieval-augmented generation, usually called RAG, can reduce this risk by giving a language model access to trusted company information. But RAG does not automatically make every answer true.
 
-A language model generates an answer from the information available in its context and from patterns encoded in its parameters. It does not automatically know which internal policy is current, which source is authoritative or whether two documents contradict each other.
+This article explains what RAG changes, where it can still fail and how I would design a safer assistant.
 
-Retrieval-augmented generation, usually shortened to RAG, adds an external knowledge step:
+This article was inspired by Netguru's webinar about RAG and AI hallucinations. The architecture and conclusions below are my own analysis, supported by the sources listed at the end.
 
-1. The user asks a question.
-2. The system searches an approved knowledge base.
-3. Relevant passages are added to the model context.
-4. The model generates an answer using those passages.
+## 1. Why a language model can sound right and still be wrong
 
-The original RAG research described this as combining a model's parametric memory with an external, non-parametric memory. In practical product terms, it means that company documents can be updated without retraining the model, and answers can be linked back to source material.
+A language model generates an answer by predicting what text should come next.
+
+That makes it very good at producing fluent explanations, but fluency is not the same as verification.
+
+A general model may not know:
+
+- which company policy is currently active;
+- whether a document has been replaced;
+- which country or product a rule applies to;
+- whether two internal documents contradict each other;
+- whether the answer requires human approval.
+
+Without access to reliable company data, the model may produce an answer that sounds reasonable but is not supported by the real policy.
+
+This is especially risky when the chatbot answers questions about:
+
+- refunds;
+- prices;
+- eligibility;
+- contracts;
+- medical information;
+- legal rights;
+- financial decisions.
+
+For these questions, a helpful guess is not good enough.
+
+## 2. What RAG actually changes
+
+RAG adds a search step before the model generates its answer.
+
+Instead of relying only on what the model learned during training, the application searches an approved knowledge base and gives the relevant passages to the model.
 
 <RagArchitecture />
 
-This is a meaningful improvement over asking a general model to answer a company-specific question from memory. It gives the model evidence that is current, private and domain-specific.
+The basic flow is:
 
-It does not prove that the final answer is correct.
+1. The user asks a question.
+2. The system searches approved documents.
+3. It retrieves the most relevant passages.
+4. The passages are added to the model's context.
+5. The model generates an answer based on that evidence.
+6. The response includes the source.
 
-## 2. The ingestion pipeline is part of the product
+For example, an airline assistant could search:
 
-A RAG request starts long before the user sends a message.
+- current refund policies;
+- fare conditions;
+- country-specific rules;
+- customer-support documentation;
+- approved internal guidance.
 
-Documents first need to be collected, parsed, cleaned, divided into useful chunks and enriched with metadata. Embeddings may then represent those chunks as vectors so the system can retrieve semantically related content.
+This has several advantages.
 
-A basic ingestion pipeline might look like this:
+The company can update its information without retraining the model. The assistant can answer questions using private or domain-specific documents. It can also show where the answer came from.
+
+Embeddings are often used to help find passages that are similar in meaning to the user's question. The important point for the reader is not the mathematics. The important point is that RAG gives the model relevant evidence before it answers.
+
+That is a meaningful improvement.
+
+It is still not a guarantee.
+
+## 3. Why RAG can still fail
+
+The phrase "RAG stops hallucinations" is too strong.
+
+A RAG system can retrieve evidence and still produce an unreliable answer.
+
+### The source is outdated
+
+The knowledge base may contain an old policy that is no longer valid.
+
+The system can retrieve that document correctly and still give the wrong answer because the source itself is wrong.
+
+This is why documents need useful metadata such as:
+
+- version;
+- effective date;
+- country;
+- product;
+- approval status.
+
+The system should prefer current, approved sources rather than treating every document as equally trustworthy.
+
+### The wrong passage is retrieved
+
+A user may ask:
+
+> Can I request a bereavement discount after my flight?
+
+The system might retrieve a general page about bereavement fares but miss the sentence explaining that retrospective requests are not allowed.
+
+The answer may then look grounded while leaving out the most important condition.
+
+Retrieval is therefore not only about finding related text. It is about finding the text that actually answers the question.
+
+### Two documents conflict
+
+One document may say a refund is allowed while another says it is not.
+
+This can happen when:
+
+- an old policy was not removed;
+- regional rules differ;
+- a draft was indexed accidentally;
+- two teams maintain overlapping documentation.
+
+The model should not quietly choose one and present it as certain.
+
+When the evidence conflicts, the safer behaviour is to explain the conflict or escalate the question.
+
+### The model adds unsupported details
+
+Even when the correct passage is available, the model may:
+
+- overgeneralise the rule;
+- combine two separate policies;
+- omit an exception;
+- add a condition that is not present;
+- make the answer sound more certain than the source allows.
+
+This is why displaying a citation is not enough by itself. The source must actually support the claims in the answer.
+
+## 4. A safer answer flow
+
+A reliable assistant needs more than retrieval. It needs a clear decision about whether the available evidence is strong enough.
+
+<RagSafeAnswerFlow />
+
+I would design three possible outcomes.
+
+### Supported answer
+
+The system finds current, consistent evidence that directly answers the question.
+
+It returns:
+
+- a concise answer;
+- the important conditions;
+- the source;
+- the policy date when relevant.
+
+### Clarification required
+
+The answer depends on missing information.
+
+For example:
+
+- Which country are you travelling from?
+- When was the ticket purchased?
+- Which fare type do you have?
+- Has the journey already happened?
+
+Instead of guessing, the assistant asks for the missing detail.
+
+### Refuse or escalate
+
+The system cannot find enough evidence, or the documents conflict.
+
+The assistant should say something like:
+
+> I do not have enough approved information to answer this reliably. Please contact customer support for confirmation.
+
+That may feel less impressive than always producing an answer, but it is a much safer product decision.
+
+The goal is not to maximise the number of questions answered.
+
+The goal is to answer only when the system has enough evidence.
+
+## 5. Keep the first production design understandable
+
+For a company-policy assistant, my first version would include:
+
+- approved documents as the source of truth;
+- document versions and effective dates;
+- semantic and keyword search;
+- filtering by country, product and policy status;
+- a check for weak or conflicting evidence;
+- answers with visible sources;
+- a refusal or human-escalation path;
+- logs for investigating disputed answers.
+
+I would not begin with a highly autonomous agent unless testing showed that simple retrieval was not enough.
+
+An agent can rewrite questions and perform several searches, which may improve difficult cases. But it also adds cost, latency and another layer that can behave unpredictably.
+
+The simplest system that meets the reliability requirement is usually the best starting point.
+
+## 6. How I would test it
+
+A few successful conversations are not enough to prove that the assistant is reliable.
+
+I would create a test dataset before launch.
+
+It should include:
+
+### Normal questions
+
+Questions with clear answers in the approved documents.
 
 ```text
-Source systems
-  → extract documents
-  → parse and clean content
-  → split into chunks
-  → attach metadata
-  → create embeddings
-  → store text and vectors
+What is the cancellation deadline for this fare?
 ```
 
-Useful metadata can include:
+### Reworded questions
 
-- source URL or document identifier;
-- title and section;
-- page number;
-- product, country or customer segment;
-- publication and effective dates;
-- document version;
-- owner and approval status;
-- access-control information.
+The same policy expressed in different language.
 
-This data is not decorative. It determines whether the retrieval layer can distinguish a current German refund policy from an expired Canadian policy, or an approved document from an internal draft.
-
-Poor ingestion creates errors that no prompt can reliably repair later.
-
-## 3. Retrieval is a ranking problem, not a lookup guarantee
-
-Vector similarity is useful because users rarely phrase questions exactly like the source material. However, semantic similarity does not necessarily mean that a passage answers the question.
-
-A query about whether a refund is available may retrieve:
-
-- a general refund overview;
-- an expired exception;
-- a document for another market;
-- a policy that mentions similar terminology but applies to a different fare;
-- a support article that omits an important condition.
-
-A production system therefore needs more than "take the nearest ten vectors."
-
-Possible improvements include:
-
-- hybrid keyword and vector search;
-- metadata filtering before retrieval;
-- query rewriting for ambiguous questions;
-- multiple retrieval queries;
-- reranking the candidate passages;
-- diversity controls to avoid ten near-duplicate chunks;
-- permission filtering;
-- an evidence-sufficiency check before generation.
-
-Agent-assisted retrieval, discussed in the webinar, can generate several searches instead of relying on the user's wording alone. That may improve recall, but it also adds latency, cost and another probabilistic component. I would introduce it only when evaluation shows that simpler retrieval misses important evidence.
-
-## 4. Where RAG still fails
-
-<RagFailureModes />
-
-A RAG system can fail at several independent layers.
-
-### Ingestion failure
-
-The source may be missing, badly parsed or split at the wrong boundaries. A table may lose its headings. A PDF footnote may become detached from the rule it qualifies.
-
-### Source-governance failure
-
-The knowledge base may contain outdated, duplicated or contradictory policies. Retrieval can faithfully return the wrong version.
-
-### Retrieval failure
-
-The correct source exists but is not returned, or a superficially similar passage receives a higher score.
-
-### Context failure
-
-The correct evidence is retrieved but truncated, mixed with conflicting evidence or placed in a context that is too large and noisy.
-
-### Generation failure
-
-The model may overgeneralise, combine separate rules or add an unsupported detail while producing a fluent answer.
-
-### Citation failure
-
-A response may display a real source even though the source does not support every claim in the answer. A citation is useful only when the claim-to-source relationship is checked.
-
-This is why I would avoid saying that RAG "stops hallucinations." It can substantially reduce unsupported answers, especially for domain-specific knowledge, but the system still needs controls around retrieval, generation and source quality.
-
-## 5. Refusal is a product feature
-
-One of the most important behaviours in a trustworthy assistant is the ability to say:
-
-> I do not have enough approved information to answer that.
-
-A similarity threshold can help, but a fixed number such as `0.60` is not a universal truth boundary. Scores vary by embedding model, index, chunking strategy and query type. Thresholds should be calibrated against an evaluation dataset.
-
-For a policy assistant, I would separate answers into three paths:
-
-1. **Supported answer** — sufficient, consistent evidence is available.
-2. **Clarification required** — the question is missing a country, product, date or other condition.
-3. **Refuse or escalate** — evidence is missing, conflicting or too weak.
-
-High-impact topics such as eligibility, prices, refunds, medical guidance or legal rights should use stricter evidence rules than low-risk questions such as navigation or opening hours.
-
-The assistant should not hide uncertainty behind polished language.
-
-## 6. Design the answer contract
-
-A safe architecture constrains not only what the model receives, but also what it is allowed to return.
-
-For policy questions, the response contract could require:
-
-```json
-{
-  "status": "supported | clarification_required | insufficient_evidence",
-  "answer": "string",
-  "claims": [
-    {
-      "text": "string",
-      "sourceIds": ["policy-2026-04"],
-      "support": "direct | inferred"
-    }
-  ],
-  "effectiveDate": "2026-04-01",
-  "escalationRequired": false
-}
+```text
+How late can I cancel and still receive a refund?
 ```
 
-The application can then validate:
+### Missing-information questions
 
-- every material claim has a source;
-- each source is current and approved;
-- the answer does not cite inaccessible documents;
-- unsupported statuses do not contain definitive advice;
-- high-risk responses meet stricter rules;
-- the displayed link resolves to the cited source.
+Questions that require clarification.
 
-Structured output does not eliminate model errors, but it gives the rest of the system something testable.
+```text
+Can I get my money back?
+```
 
-## 7. Evaluate retrieval and generation separately
+The correct response may depend on the ticket type, travel date or reason for cancellation.
 
-A few successful manual conversations are not enough to evaluate a RAG product.
+### Questions with no answer
 
-The test dataset should represent real questions, including difficult cases:
+The information is not available in the knowledge base.
 
-- direct questions with one clear answer;
-- paraphrased and misspelled questions;
-- questions requiring multiple passages;
-- questions with no answer in the knowledge base;
-- ambiguous questions requiring clarification;
-- outdated or conflicting sources;
-- attempts to override the assistant's policy;
-- high-risk questions that should escalate.
+The expected behaviour is refusal or escalation, not invention.
 
-I would measure at least two layers.
+### Conflicting-source questions
 
-### Retrieval quality
+The test knowledge base deliberately includes two incompatible documents.
 
-- Did the system retrieve the required source?
-- At what rank did it appear?
-- Did irrelevant passages dominate the context?
-- Were permissions and metadata filters applied correctly?
+The assistant should detect uncertainty rather than choosing one silently.
 
-### Answer quality
+### High-risk questions
 
-- Is the response supported by the retrieved context?
-- Is it relevant to the question?
-- Does it include all necessary conditions?
-- Are citations attached to the claims they support?
-- Did the system refuse when evidence was insufficient?
+Questions about money, eligibility or legal obligations should be tested more strictly than simple navigation questions.
 
-Microsoft's RAG evaluation guidance, for example, treats retrieval, groundedness, relevance and completeness as separate concerns. NVIDIA's guidance similarly distinguishes groundedness from context recall. That separation matters because an excellent generator cannot recover evidence that retrieval never supplied.
+I would evaluate two parts separately:
 
-## 8. Build a production feedback loop
+1. **Retrieval quality** — did the system find the correct evidence?
+2. **Answer quality** — did the response stay faithful to that evidence?
 
-<RagReliabilityLoop />
+This separation is important. A model cannot produce a grounded answer when the retrieval layer never supplied the correct source.
 
-Offline evaluation catches known cases. Production observability reveals cases the team did not anticipate.
+## 7. Learn from production failures
 
-I would log enough information to reconstruct a failure:
+Offline tests cover known cases. Real users will still ask questions that the team did not expect.
 
-- original and rewritten queries;
-- retrieved document identifiers and scores;
-- versions and effective dates;
-- the context supplied to the model;
-- model and prompt versions;
-- structured response and citations;
-- latency, token usage and failure status;
-- user feedback or human-review outcome.
+When a weak answer appears in production, I would use this loop:
 
-Sensitive content should be minimised, redacted where necessary and retained according to a defined policy.
+1. Capture the question, retrieved sources and final answer.
+2. Identify whether the problem came from the data, retrieval or generation.
+3. Add the question to the evaluation dataset.
+4. Fix the smallest responsible part of the system.
+5. Run the full regression suite.
+6. Deploy and continue monitoring.
 
-The useful loop is:
+This turns a production failure into a permanent test case.
 
-1. Detect a weak or disputed production answer.
-2. Reproduce it from the trace.
-3. Decide whether the problem came from data, retrieval, prompting or validation.
-4. Add the case to the evaluation dataset.
-5. Fix the narrowest responsible layer.
-6. Run the full regression suite.
-7. Deploy and continue monitoring.
+The same mistake should not be rediscovered repeatedly by different users.
 
-This turns observability into engineering feedback rather than a dashboard that nobody uses.
+Logs must still follow privacy and data-retention rules. The system should store only what is needed to investigate reliability.
 
-## 9. A safer architecture for company policy
+## 8. What the Air Canada case teaches us
 
-My first production design would use:
+The case is not simply a warning that chatbots are dangerous.
 
-- approved, versioned policy documents as the source of truth;
-- ingestion with parsing checks and metadata validation;
-- hybrid retrieval with product, market and effective-date filters;
-- reranking before context assembly;
-- explicit evidence sufficiency and conflict detection;
-- structured generation with claim-level source identifiers;
-- post-generation validation;
-- refusal or human escalation for weak evidence;
-- offline regression tests and production tracing.
+It shows that a company cannot treat its chatbot as an independent actor that owns its own mistakes.
 
-I would not begin with a complex autonomous agent unless simpler retrieval failed measured use cases. The goal is not to maximise the number of AI components. The goal is to make the decision path understandable and testable.
+Once an assistant communicates company policy, it becomes part of the product experience.
 
-## 10. What the Air Canada case changes for engineers
+That creates responsibilities across the organisation:
 
-The case does not establish a universal technical standard for every chatbot. It does show why teams cannot treat a public assistant as an independent actor that owns its own mistakes.
+- content owners must maintain trusted sources;
+- engineers must build safe answer paths;
+- product teams must define what the assistant may answer;
+- QA must test refusal and conflict cases;
+- support teams need an escalation process;
+- the organisation remains accountable for deployed behaviour.
 
-From an engineering perspective, that means:
+The problem cannot be solved by changing a prompt and hoping the model behaves better.
 
-- product owners must define which questions the assistant may answer;
-- content owners must maintain authoritative sources;
-- engineers must design refusal and escalation paths;
-- QA must test unsupported and contradictory cases;
-- operations teams must be able to reconstruct disputed answers;
-- the organisation must remain accountable for the experience it deploys.
+Reliability comes from the whole system around the model.
 
-A chatbot response is part of the product surface. Reliability cannot be delegated to the model.
+## 9. The real lesson
 
-## 11. The practical conclusion
+RAG is valuable because it gives a language model access to current, private and inspectable information.
 
-RAG is valuable because it can connect generation to current, private and inspectable evidence. It can improve factuality, make updates easier and provide provenance.
+It can reduce unsupported answers and make sources visible.
 
 But RAG is not a truth machine.
 
-The reliability of the final product depends on the whole path:
+A trustworthy assistant depends on:
 
 ```text
-source quality
-  → ingestion quality
-  → retrieval quality
-  → context quality
-  → generation constraints
-  → validation
-  → evaluation
-  → production feedback
+trusted sources
+  → careful retrieval
+  → evidence checks
+  → grounded answers
+  → safe refusal
+  → continuous testing
 ```
 
-The strongest design is not the one that always produces an answer. It is the one that knows when an answer is supported, shows the evidence and fails safely when it is not.
+The strongest assistant is not the one that always answers.
+
+It is the one that knows when the evidence is strong enough, shows where the answer came from and fails safely when it is uncertain.
 
 ## Sources and further reading
 
 - [Netguru webinar: How RAG Stops Your AI From Making Things Up](https://www.linkedin.com/posts/netguru_air-canadas-chatbot-promised-a-passenger-activity-7482382071508819969-fmhs)
-- [Moffatt v. Air Canada, 2024 BCCRT 149 (CanLII)](https://www.canlii.org/en/bc/bccrt/doc/2024/2024bccrt149/2024bccrt149.html)
+- [Moffatt v. Air Canada, 2024 BCCRT 149](https://www.canlii.org/en/bc/bccrt/doc/2024/2024bccrt149/2024bccrt149.html)
 - [Retrieval-Augmented Generation for Knowledge-Intensive NLP Tasks](https://arxiv.org/abs/2005.11401)
 - [Retrieval-Augmented Generation for Large Language Models: A Survey](https://arxiv.org/abs/2312.10997)
-- [Microsoft Foundry: RAG evaluators](https://learn.microsoft.com/en-us/azure/ai-foundry/concepts/evaluation-evaluators/rag-evaluators)
-- [NVIDIA RAG Blueprint: evaluation guidance](https://docs.nvidia.com/rag/latest/evaluate.html)
-- [Netguru: Trusted AI chatbot for dental professionals](https://www.netguru.com/clients/trusted-ai-chatbot-for-dental-professionals)
+- [Microsoft Foundry: RAG evaluators](https://learn.microsoft.com/en-us/azure/foundry/concepts/evaluation-evaluators/rag-evaluators)

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -423,3 +423,160 @@ a { color: inherit; }
 .checker-limitations { display: flex; gap: 1rem; margin-top: 3rem; padding: 1.5rem; border-radius: .65rem; background: var(--surface-muted); }.checker-limitations > svg { flex: 0 0 auto; color: var(--accent-strong); }.checker-limitations h2 { font-family: var(--font-source-sans), sans-serif; font-size: 1.2rem; }.checker-limitations p { margin-bottom: 0; font-size: 1rem; }
 @keyframes checker-spin { to { transform: rotate(360deg); } }
 @media (max-width: 700px) { .checker-page { width: min(100% - 1.25rem, 62rem); }.checker-input-row { display: grid; }.checker-input-row button { width: 100%; }.checker-summary { grid-template-columns: 1fr; }.checker-summary div { border-right: 0; border-bottom: 1px solid var(--border); }.checker-summary div:last-child { border-bottom: 0; } }
+
+/* RAG article visuals */
+.rag-visual {
+  margin: 2.25rem 0;
+  border: 1px solid var(--border);
+  background: color-mix(in srgb, var(--accent) 4%, var(--surface));
+}
+
+.rag-visual figcaption {
+  padding: 1rem 1.25rem;
+  border-bottom: 1px solid var(--border);
+  color: var(--text);
+  font-weight: 750;
+}
+
+.rag-architecture {
+  padding-bottom: 1rem;
+  overflow-x: auto;
+}
+
+.rag-architecture svg {
+  display: block;
+  width: 100%;
+  min-width: 760px;
+  height: auto;
+  padding: 1rem;
+  box-sizing: border-box;
+}
+
+.rag-node rect {
+  fill: var(--surface);
+  stroke: var(--border);
+  stroke-width: 1.5;
+}
+
+.rag-node text {
+  fill: var(--text);
+  font-family: var(--font-source-sans), Arial, sans-serif;
+  font-size: 13px;
+  font-weight: 750;
+}
+
+.rag-node text.rag-node-type {
+  fill: var(--text-muted);
+  font-size: 9px;
+  font-weight: 650;
+}
+
+.rag-relationships path {
+  fill: none;
+  stroke: var(--accent);
+  stroke-width: 2;
+}
+
+.rag-relationships marker path {
+  fill: var(--accent);
+}
+
+.rag-relationships .rag-safe-path {
+  stroke-dasharray: 6 5;
+}
+
+.rag-edge-labels text {
+  fill: var(--text-muted);
+  font-family: var(--font-source-sans), Arial, sans-serif;
+  font-size: 9px;
+  font-weight: 650;
+  paint-order: stroke;
+  stroke: var(--surface);
+  stroke-width: 4px;
+  stroke-linejoin: round;
+}
+
+.rag-text-equivalent {
+  margin: 0 1.25rem 0.25rem;
+  color: var(--text-muted);
+}
+
+.rag-text-equivalent summary {
+  cursor: pointer;
+  color: var(--accent-strong);
+  font-weight: 750;
+}
+
+.rag-failure-grid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 1px;
+  background: var(--border);
+}
+
+.rag-failure-grid article {
+  min-height: 11rem;
+  padding: 1.25rem;
+  background: var(--surface);
+}
+
+.rag-failure-grid span,
+.rag-reliability-loop li span {
+  color: var(--accent-strong);
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+  font-size: 0.78rem;
+  font-weight: 750;
+}
+
+.rag-failure-grid h3 {
+  margin: 1rem 0 0.5rem;
+  font-family: var(--font-source-sans), Arial, sans-serif;
+  font-size: 1.1rem;
+}
+
+.rag-failure-grid p {
+  margin: 0;
+  color: var(--text-muted);
+  line-height: 1.55;
+}
+
+.rag-reliability-loop ol {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 1px;
+  padding: 0;
+  margin: 0;
+  background: var(--border);
+  list-style: none;
+}
+
+.rag-reliability-loop li {
+  display: grid;
+  min-height: 7rem;
+  align-content: space-between;
+  gap: 1rem;
+  padding: 1.1rem;
+  background: var(--surface);
+}
+
+.rag-reliability-loop strong {
+  font-size: 1rem;
+}
+
+.rag-reliability-loop > p {
+  margin: 0;
+  padding: 1rem 1.25rem;
+  border-top: 1px solid var(--border);
+  color: var(--text-muted);
+}
+
+@media (max-width: 700px) {
+  .rag-failure-grid,
+  .rag-reliability-loop ol {
+    grid-template-columns: 1fr;
+  }
+
+  .rag-failure-grid article {
+    min-height: auto;
+  }
+}

--- a/src/components/writing/ArticleContent.tsx
+++ b/src/components/writing/ArticleContent.tsx
@@ -1,17 +1,28 @@
-import { compileMDX } from 'next-mdx-remote/rsc';
-import type { ComponentProps } from 'react';
+import { compileMDX } from 'next-mdx-remote/rsc'
+import type { ComponentProps } from 'react'
 
-import { ShortCodeTradeoffMatrix } from './ShortCodeTradeoffMatrix';
-import { UrlShortenerArchitecture } from './UrlShortenerArchitecture';
+import { RagArchitecture } from './RagArchitecture'
+import { RagFailureModes } from './RagFailureModes'
+import { RagReliabilityLoop } from './RagReliabilityLoop'
+import { ShortCodeTradeoffMatrix } from './ShortCodeTradeoffMatrix'
+import { UrlShortenerArchitecture } from './UrlShortenerArchitecture'
 
 const components = {
   pre: (props: ComponentProps<'pre'>) => <pre {...props} />,
   code: (props: ComponentProps<'code'>) => <code {...props} />,
+  table: ({ children, ...props }: ComponentProps<'table'>) => (
+    <div className="writing-content-table">
+      <table {...props}>{children}</table>
+    </div>
+  ),
   UrlShortenerArchitecture,
   ShortCodeTradeoffMatrix,
-};
+  RagArchitecture,
+  RagFailureModes,
+  RagReliabilityLoop,
+}
 
 export default async function ArticleContent({ source }: { source: string }) {
-  const { content } = await compileMDX({ source, components });
-  return content;
+  const { content } = await compileMDX({ source, components })
+  return content
 }

--- a/src/components/writing/ArticleContent.tsx
+++ b/src/components/writing/ArticleContent.tsx
@@ -4,6 +4,7 @@ import type { ComponentProps } from 'react'
 import { RagArchitecture } from './RagArchitecture'
 import { RagFailureModes } from './RagFailureModes'
 import { RagReliabilityLoop } from './RagReliabilityLoop'
+import { RagSafeAnswerFlow } from './RagSafeAnswerFlow'
 import { ShortCodeTradeoffMatrix } from './ShortCodeTradeoffMatrix'
 import { UrlShortenerArchitecture } from './UrlShortenerArchitecture'
 
@@ -20,6 +21,7 @@ const components = {
   RagArchitecture,
   RagFailureModes,
   RagReliabilityLoop,
+  RagSafeAnswerFlow,
 }
 
 export default async function ArticleContent({ source }: { source: string }) {

--- a/src/components/writing/RagArchitecture.tsx
+++ b/src/components/writing/RagArchitecture.tsx
@@ -1,0 +1,93 @@
+const stages = [
+  { label: 'User question', type: 'Input', x: 20, y: 135 },
+  { label: 'Query processing', type: 'Rewrite + classify', x: 190, y: 135 },
+  { label: 'Retrieval', type: 'Hybrid search', x: 380, y: 55 },
+  { label: 'Reranking', type: 'Select evidence', x: 550, y: 55 },
+  { label: 'Evidence check', type: 'Sufficient?', x: 380, y: 215 },
+  { label: 'Generate answer', type: 'Structured output', x: 550, y: 215 },
+  { label: 'Validate', type: 'Claims + sources', x: 720, y: 215 },
+  { label: 'Refuse / escalate', type: 'Safe failure', x: 550, y: 330 },
+] as const
+
+const width = 145
+const height = 62
+
+export function RagArchitecture() {
+  return (
+    <figure className="rag-visual rag-architecture">
+      <figcaption>
+        Retrieval is only one stage in a production answer path
+      </figcaption>
+
+      <svg
+        viewBox="0 0 900 430"
+        role="img"
+        aria-labelledby="rag-architecture-title rag-architecture-description"
+      >
+        <title id="rag-architecture-title">Production RAG answer architecture</title>
+        <desc id="rag-architecture-description">
+          A user question is processed, used to retrieve and rerank evidence, checked
+          for sufficiency, then either generates a validated cited answer or follows
+          a refusal and escalation path.
+        </desc>
+
+        <defs>
+          <marker
+            id="rag-arrow"
+            markerWidth="8"
+            markerHeight="8"
+            refX="7"
+            refY="4"
+            orient="auto"
+          >
+            <path d="M0,0 L8,4 L0,8 Z" />
+          </marker>
+        </defs>
+
+        <g className="rag-relationships">
+          <path d="M165 166 L190 166" markerEnd="url(#rag-arrow)" />
+          <path d="M335 155 L380 96" markerEnd="url(#rag-arrow)" />
+          <path d="M525 86 L550 86" markerEnd="url(#rag-arrow)" />
+          <path d="M622 117 L500 215" markerEnd="url(#rag-arrow)" />
+          <path d="M525 246 L550 246" markerEnd="url(#rag-arrow)" />
+          <path d="M695 246 L720 246" markerEnd="url(#rag-arrow)" />
+          <path className="rag-safe-path" d="M452 277 L550 350" markerEnd="url(#rag-arrow)" />
+        </g>
+
+        <g className="rag-edge-labels">
+          <text x="520" y="174">candidate passages</text>
+          <text x="535" y="232">enough evidence</text>
+          <text x="455" y="322">weak or conflicting</text>
+        </g>
+
+        {stages.map((stage) => (
+          <g key={stage.label} className="rag-node">
+            <rect x={stage.x} y={stage.y} width={width} height={height} rx="7" />
+            <text x={stage.x + width / 2} y={stage.y + 25} textAnchor="middle">
+              {stage.label}
+            </text>
+            <text
+              className="rag-node-type"
+              x={stage.x + width / 2}
+              y={stage.y + 45}
+              textAnchor="middle"
+            >
+              {stage.type}
+            </text>
+          </g>
+        ))}
+      </svg>
+
+      <details className="rag-text-equivalent">
+        <summary>Read the architecture as text</summary>
+        <ol>
+          <li>The application classifies and, where useful, rewrites the question.</li>
+          <li>Hybrid retrieval finds candidate passages and a reranker orders them.</li>
+          <li>An evidence check tests whether the sources are sufficient and consistent.</li>
+          <li>Supported questions receive structured, cited answers that are validated.</li>
+          <li>Weak or conflicting evidence follows a refusal or human-escalation path.</li>
+        </ol>
+      </details>
+    </figure>
+  )
+}

--- a/src/components/writing/RagFailureModes.tsx
+++ b/src/components/writing/RagFailureModes.tsx
@@ -1,0 +1,49 @@
+const failureModes = [
+  {
+    stage: '01',
+    title: 'Ingestion',
+    description: 'Missing documents, broken parsing, weak chunk boundaries or lost table structure.',
+  },
+  {
+    stage: '02',
+    title: 'Governance',
+    description: 'Outdated, duplicated, contradictory or unapproved source material.',
+  },
+  {
+    stage: '03',
+    title: 'Retrieval',
+    description: 'The correct evidence exists but does not rank highly enough.',
+  },
+  {
+    stage: '04',
+    title: 'Context',
+    description: 'Useful passages are truncated, noisy or mixed with conflicting evidence.',
+  },
+  {
+    stage: '05',
+    title: 'Generation',
+    description: 'The answer adds, combines or overgeneralises claims beyond the evidence.',
+  },
+  {
+    stage: '06',
+    title: 'Citation',
+    description: 'A real source is shown, but it does not support every material claim.',
+  },
+] as const
+
+export function RagFailureModes() {
+  return (
+    <figure className="rag-visual rag-failure-modes">
+      <figcaption>Six places a grounded assistant can still become unreliable</figcaption>
+      <div className="rag-failure-grid">
+        {failureModes.map((mode) => (
+          <article key={mode.stage}>
+            <span>{mode.stage}</span>
+            <h3>{mode.title}</h3>
+            <p>{mode.description}</p>
+          </article>
+        ))}
+      </div>
+    </figure>
+  )
+}

--- a/src/components/writing/RagReliabilityLoop.tsx
+++ b/src/components/writing/RagReliabilityLoop.tsx
@@ -1,0 +1,28 @@
+const steps = [
+  'Observe production',
+  'Triage failures',
+  'Add evaluation case',
+  'Fix responsible layer',
+  'Run regression suite',
+  'Deploy and monitor',
+] as const
+
+export function RagReliabilityLoop() {
+  return (
+    <figure className="rag-visual rag-reliability-loop">
+      <figcaption>Production failures should become permanent regression tests</figcaption>
+      <ol>
+        {steps.map((step, index) => (
+          <li key={step}>
+            <span>{String(index + 1).padStart(2, '0')}</span>
+            <strong>{step}</strong>
+          </li>
+        ))}
+      </ol>
+      <p>
+        The loop is complete only when a disputed answer can be reproduced, fixed
+        and protected against recurrence.
+      </p>
+    </figure>
+  )
+}

--- a/src/components/writing/RagSafeAnswerFlow.tsx
+++ b/src/components/writing/RagSafeAnswerFlow.tsx
@@ -1,0 +1,31 @@
+const outcomes = [
+  {
+    label: 'Supported answer',
+    description: 'Current, consistent evidence directly answers the question.',
+  },
+  {
+    label: 'Clarification required',
+    description: 'A missing detail such as country, product or date changes the answer.',
+  },
+  {
+    label: 'Refuse or escalate',
+    description: 'Evidence is weak, missing or conflicting, so the assistant does not guess.',
+  },
+] as const
+
+export function RagSafeAnswerFlow() {
+  return (
+    <figure className="rag-visual rag-reliability-loop rag-safe-answer-flow">
+      <figcaption>A safe assistant selects an outcome based on evidence</figcaption>
+      <ol>
+        {outcomes.map((outcome, index) => (
+          <li key={outcome.label}>
+            <span>{String(index + 1).padStart(2, '0')}</span>
+            <strong>{outcome.label}</strong>
+            <small>{outcome.description}</small>
+          </li>
+        ))}
+      </ol>
+    </figure>
+  )
+}


### PR DESCRIPTION
Summary

- Adds a new long-form MDX article based on the Air Canada chatbot case
- Introduces three accessible RAG architecture and reliability components
- Registers the components in the MDX renderer
- Adds responsive, theme-aware styles
- Includes technical, legal and webinar source links

Validation

- npm run lint
- npm run typecheck
- npm run build
- Browser review at desktop and mobile widths, including dark mode